### PR TITLE
Use null-safe & optional chaining

### DIFF
--- a/lib/SpladeCore.vue
+++ b/lib/SpladeCore.vue
@@ -247,20 +247,16 @@ function request(url, method, data, headers) {
             newPageFromResponse(response);
         })
         .catch((error) => {
-            const spladeData = error.response.data.splade;
-
-            if (spladeData) {
+            if (spladeData = error.response?.data?.splade) {
                 setSpladeData(spladeData);
             }
 
-            if (error.response.status == 422) {
+            if (error.response?.status == 422) {
                 return;
             }
 
             onServerError(
-                error.response.data.html
-                    ? error.response.data.html
-                    : error.response.data
+                error.response?.data?.html || error.response?.data
             );
         });
 


### PR DESCRIPTION
When you broadcast an event and you receive a response from Pusher, this gets logged to the console.

![image](https://user-images.githubusercontent.com/3874381/180810923-5e3425b7-df6d-448e-b62c-54cfb74c0425.png)
