### PR TITLE
Refactored Transitions + Public Transition/Animation API

### DIFF
--- a/ExtractTransitionClasses.php
+++ b/ExtractTransitionClasses.php
@@ -13,5 +13,5 @@ $classes = implode(' ', $transitionRepository->classes());
 
 file_put_contents(
     __DIR__ . '/resources/views/transitions/classes.blade.php',
-    "<div class='{$classes}'>\n<!-- This is a dummy template so that Tailwind won't purge these transition classes... -->\n</div>",
+    "<div class='{$classes}'>\n<!-- This is an automatically generated template so that Tailwind won't purge these transition classes... -->\n</div>",
 );

--- a/ExtractTransitionClasses.php
+++ b/ExtractTransitionClasses.php
@@ -1,0 +1,17 @@
+<?php
+
+use ProtoneMedia\Splade\ServiceProvider;
+use ProtoneMedia\Splade\TransitionRepository;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$transitionRepository = new TransitionRepository;
+
+ServiceProvider::registerTransitionAnimations($transitionRepository);
+
+$classes = implode(' ', $transitionRepository->classes());
+
+file_put_contents(
+    __DIR__ . '/resources/views/transitions/classes.blade.php',
+    "<div class='{$classes}'>\n<!-- This is a dummy template so that Tailwind won't purge these transition classes... -->\n</div>",
+);

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -2,8 +2,6 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -15,7 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // App::terminating(fn () => Artisan::call('view:clear'));
+        //
     }
 
     /**

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -13,7 +15,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        App::terminating(fn () => Artisan::call('view:clear'));
     }
 
     /**

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -15,7 +15,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        App::terminating(fn () => Artisan::call('view:clear'));
+        // App::terminating(fn () => Artisan::call('view:clear'));
     }
 
     /**

--- a/app/resources/views/transition/default.blade.php
+++ b/app/resources/views/transition/default.blade.php
@@ -1,0 +1,17 @@
+@extends('layout')
+
+@section('content')
+
+TransitionDefault
+
+<x-splade-toggle>
+    <button @click.prevent="toggle">Toggle</button>
+
+    <div class="p-4 bg-red-500">
+        <x-splade-transition show="toggled">
+            <div class="bg-green-500 p-4">Slot</div>
+        </x-splade-transition>
+    </div>
+</x-splade-toggle>
+
+@endsection

--- a/app/resources/views/transition/default.blade.php
+++ b/app/resources/views/transition/default.blade.php
@@ -2,13 +2,25 @@
 
 @section('content')
 
+@php
+\ProtoneMedia\Splade\Facades\Animation::new(
+    name: 'custom-demo',
+    enter: 'transform transform ease-in-out duration-300',
+    enterFrom: 'opacity-0 -translate-x-full',
+    enterTo: 'opacity-100 translate-x-0',
+    leave: 'transform transform ease-in-out duration-300',
+    leaveFrom: 'opacity-100 translate-x-0',
+    leaveTo: 'opacity-0 -translate-x-full',
+);
+@endphp
+
 TransitionDefault
 
 <x-splade-toggle>
     <button @click.prevent="toggle">Toggle</button>
 
     <div class="p-4 bg-red-500">
-        <x-splade-transition show="toggled">
+        <x-splade-transition animation="custom-demo" show="toggled">
             <div class="bg-green-500 p-4">Slot</div>
         </x-splade-transition>
     </div>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -158,6 +158,8 @@ Route::middleware('splade')->group(function () {
     Route::view('toggle/single', 'toggle.single')->name('toggle.single');
     Route::view('toggle/multiple', 'toggle.multiple')->name('toggle.multiple');
 
+    Route::view('transition/default', 'transition.default')->name('transition.default');
+
     Route::prefix('table')->group(function () {
         $table = new UserTableView;
 

--- a/app/tests/Browser/TransitionTest.php
+++ b/app/tests/Browser/TransitionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Browser;
+
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class TransitionTest extends DuskTestCase
+{
+    /** @test */
+    public function it_can_add_custom_animations()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/transition/default')
+                ->waitForText('TransitionDefault')
+                ->press('Toggle')
+                ->assertDontSee('Slot')
+                ->waitForText('Slot')
+                ->assertSee('Slot');
+        });
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/pint"
+        "format": "vendor/bin/pint",
+        "extract-transitions": "@php ExtractTransitionClasses.php"
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -55,10 +55,10 @@
                 "ProtoneMedia\\Splade\\ServiceProvider"
             ],
             "aliases": {
+                "Animation": "ProtoneMedia\\Splade\\Facades\\Animation",
                 "SEO": "ProtoneMedia\\Splade\\Facades\\SEO",
                 "Splade": "ProtoneMedia\\Splade\\Facades\\Splade",
-                "Toast": "ProtoneMedia\\Splade\\Facades\\Toast",
-                "Transition": "ProtoneMedia\\Splade\\Facades\\Transition"
+                "Toast": "ProtoneMedia\\Splade\\Facades\\Toast"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
             "aliases": {
                 "SEO": "ProtoneMedia\\Splade\\Facades\\SEO",
                 "Splade": "ProtoneMedia\\Splade\\Facades\\Splade",
-                "Toast": "ProtoneMedia\\Splade\\Facades\\Toast"
+                "Toast": "ProtoneMedia\\Splade\\Facades\\Toast",
+                "Transition": "ProtoneMedia\\Splade\\Facades\\Transition"
             }
         }
     },

--- a/lib/Components/Confirm.vue
+++ b/lib/Components/Confirm.vue
@@ -1,9 +1,4 @@
 <script>
-import {
-    Dialog,
-    DialogPanel,
-} from "@headlessui/vue";
-
 import { Splade } from "../Splade.js";
 
 export default {
@@ -106,9 +101,6 @@ export default {
             cancel: this.cancel,
             confirm: this.confirm,
             emitClose: this.emitClose,
-
-            Dialog,
-            DialogPanel,
         });
     },
 };

--- a/lib/Components/Confirm.vue
+++ b/lib/Components/Confirm.vue
@@ -2,8 +2,6 @@
 import {
     Dialog,
     DialogPanel,
-    TransitionRoot,
-    TransitionChild,
 } from "@headlessui/vue";
 
 import { Splade } from "../Splade.js";
@@ -111,8 +109,6 @@ export default {
 
             Dialog,
             DialogPanel,
-            TransitionRoot,
-            TransitionChild,
         });
     },
 };

--- a/lib/Components/Dialog.vue
+++ b/lib/Components/Dialog.vue
@@ -1,0 +1,12 @@
+<script>
+import { Dialog, DialogPanel } from "@headlessui/vue";
+
+export default {
+    render() {
+        return this.$slots.default({
+            Dialog,
+            DialogPanel,
+        });
+    },
+};
+</script>

--- a/lib/Components/Toast.vue
+++ b/lib/Components/Toast.vue
@@ -1,6 +1,4 @@
 <script>
-import { TransitionRoot, TransitionChild } from "@headlessui/vue";
-
 export default {
     props: {
         toastKey: {
@@ -46,8 +44,6 @@ export default {
             show: this.show,
             setShow: this.setShow,
             emitDismiss: this.emitDismiss,
-            TransitionRoot,
-            TransitionChild,
         });
     },
 };

--- a/lib/Components/Toasts.vue
+++ b/lib/Components/Toasts.vue
@@ -1,5 +1,4 @@
 <script>
-import { TransitionRoot, TransitionChild } from "@headlessui/vue";
 import { Splade } from "../Splade.js";
 import Render from "./Render.vue";
 
@@ -43,8 +42,6 @@ export default {
             dismissToast: this.dismissToast,
             hasBackdrop: this.hasBackdrop,
             Render,
-            TransitionRoot,
-            TransitionChild,
         });
     },
 };

--- a/lib/SpladePlugin.js
+++ b/lib/SpladePlugin.js
@@ -3,6 +3,7 @@ import isObject from "lodash-es/isObject";
 import Confirm from "./Components/Confirm.vue";
 import Data from "./Components/Data.vue";
 import Defer from "./Components/Defer.vue";
+import Dialog from "./Components/Dialog.vue";
 import Dropdown from "./Components/Dropdown.vue";
 import Errors from "./Components/Errors.vue";
 import Event from "./Components/Event.vue";
@@ -40,6 +41,7 @@ export default {
             .component(`${prefix}Confirm`, Confirm)
             .component(`${prefix}Data`, Data)
             .component(`${prefix}Defer`, Defer)
+            .component(`${prefix}Dialog`, Dialog)
             .component(`${prefix}Dropdown`, Dropdown)
             .component(`${prefix}Errors`, Errors)
             .component(`${prefix}Event`, Event)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "dev": "vite build --watch",
     "build": "vite build",
     "eslint": "./node_modules/.bin/eslint app/resources/js/ lib/ stubs/ --ext .js,.vue --fix",
-    "pre-publish": "npm upgrade && vite build && npm pack"
+    "pre-publish": "composer extract-transitions && npm upgrade && vite build && npm pack"
   },
   "peerDependencies": {
     "axios": "^0.27",

--- a/resources/views/button-with-dropdown.blade.php
+++ b/resources/views/button-with-dropdown.blade.php
@@ -1,4 +1,4 @@
-<x-dynamic-component :component="$wrapperName" {{ $attributes->class('w-full bg-white border border-gray-300 rounded-md shadow-sm px-2.5 sm:px-4 py-2 inline-flex justify-center text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500') }}>
+<x-dynamic-component :component="Splade::component('dropdown')" {{ $attributes->class('w-full bg-white border border-gray-300 rounded-md shadow-sm px-2.5 sm:px-4 py-2 inline-flex justify-center text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500') }}>
   <x-slot:trigger>
     {{ $button }}
   </x-slot:trigger>

--- a/resources/views/button-with-dropdown.blade.php
+++ b/resources/views/button-with-dropdown.blade.php
@@ -1,4 +1,4 @@
-<x-dynamic-component :component="Splade::component('dropdown')" {{ $attributes->class('w-full bg-white border border-gray-300 rounded-md shadow-sm px-2.5 sm:px-4 py-2 inline-flex justify-center text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500') }}>
+<x-splade-component is="dropdown" {{ $attributes->class('w-full bg-white border border-gray-300 rounded-md shadow-sm px-2.5 sm:px-4 py-2 inline-flex justify-center text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500') }}>
   <x-slot:trigger>
     {{ $button }}
   </x-slot:trigger>
@@ -6,4 +6,4 @@
   <div class="mt-2 min-w-max rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5">
     {{ $slot }}
   </div>
-</x-dynamic-component>
+</x-splade-component>

--- a/resources/views/confirm.blade.php
+++ b/resources/views/confirm.blade.php
@@ -5,8 +5,8 @@
     default-cancel-button="Cancel"
 >
     <template #default="confirm">
-        <x-dynamic-component :component="Splade::component('transition')" as="template" show="confirm.isOpen">
-            <component :is="confirm.Dialog" as="div" class="relative z-30" @close="confirm.setIsOpen(false)">
+        <x-dynamic-component :component="Splade::component('transition')" show="confirm.isOpen">
+            <component :is="confirm.Dialog" class="relative z-30" @close="confirm.setIsOpen(false)">
                 <x-dynamic-component
                     :component="Splade::component('transition')"
                     child
@@ -16,7 +16,7 @@
 
                 <div class="fixed z-30 inset-0 overflow-y-auto">
                     <div class="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
-                        <x-dynamic-component :component="Splade::component('transition')" child animation="fade" as="template" after-leave="confirm.emitClose">
+                        <x-dynamic-component :component="Splade::component('transition')" child animation="fade" after-leave="confirm.emitClose">
                             <component :is="confirm.DialogPanel"
                                 class="relative bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
                                 <div class="sm:flex sm:items-start">

--- a/resources/views/confirm.blade.php
+++ b/resources/views/confirm.blade.php
@@ -5,10 +5,10 @@
     default-cancel-button="Cancel"
 >
     <template #default="confirm">
-        <x-dynamic-component :component="Splade::component('transition')" show="confirm.isOpen">
+        <x-splade-component is="transition" show="confirm.isOpen">
             <component :is="confirm.Dialog" class="relative z-30" @close="confirm.setIsOpen(false)">
-                <x-dynamic-component
-                    :component="Splade::component('transition')"
+                <x-splade-component
+                    is="transition"
                     child
                     animation="opacity"
                     class="fixed inset-0 bg-black/75"
@@ -16,7 +16,7 @@
 
                 <div class="fixed z-30 inset-0 overflow-y-auto">
                     <div class="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
-                        <x-dynamic-component :component="Splade::component('transition')" child animation="fade" after-leave="confirm.emitClose">
+                        <x-splade-component is="transition" child animation="fade" after-leave="confirm.emitClose">
                             <component :is="confirm.DialogPanel"
                                 class="relative bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
                                 <div class="sm:flex sm:items-start">
@@ -45,10 +45,10 @@
                                     />
                                 </div>
                             </component>
-                        </x-dynamic-component>
+                        </x-splade-component>
                     </div>
                 </div>
             </component>
-        </x-dynamic-component>
+        </x-splade-component>
     </template>
 </SpladeConfirm>

--- a/resources/views/confirm.blade.php
+++ b/resources/views/confirm.blade.php
@@ -6,7 +6,7 @@
 >
     <template #default="confirm">
         <x-splade-component is="transition" show="confirm.isOpen">
-            <component :is="confirm.Dialog" class="relative z-30" @close="confirm.setIsOpen(false)">
+            <x-splade-component is="dialog" class="relative z-30" close="confirm.setIsOpen(false)">
                 <x-splade-component
                     is="transition"
                     child
@@ -17,8 +17,7 @@
                 <div class="fixed z-30 inset-0 overflow-y-auto">
                     <div class="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
                         <x-splade-component is="transition" child animation="fade" after-leave="confirm.emitClose">
-                            <component :is="confirm.DialogPanel"
-                                class="relative bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
+                            <x-splade-component is="dialog" panel class="relative bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
                                 <div class="sm:flex sm:items-start">
                                     <div class="text-center sm:mt-0 sm:text-left">
                                         <h3 class="text-lg leading-6 font-medium text-gray-900" v-text="confirm.title" />
@@ -44,11 +43,11 @@
                                         v-text="confirm.cancelButton"
                                     />
                                 </div>
-                            </component>
+                            </x-splade-component>
                         </x-splade-component>
                     </div>
                 </div>
-            </component>
+            </x-splade-component>
         </x-splade-component>
     </template>
 </SpladeConfirm>

--- a/resources/views/confirm.blade.php
+++ b/resources/views/confirm.blade.php
@@ -5,34 +5,18 @@
     default-cancel-button="Cancel"
 >
     <template #default="confirm">
-        <component :is="confirm.TransitionRoot" as="template" :show="confirm.isOpen">
+        <x-dynamic-component :component="Splade::component('transition')" as="template" show="confirm.isOpen">
             <component :is="confirm.Dialog" as="div" class="relative z-30" @close="confirm.setIsOpen(false)">
-                <component
-                    :is="confirm.TransitionChild"
-                    as="template"
-                    enter="ease-out duration-300"
-                    enter-from="opacity-0"
-                    enter-to="opacity-100"
-                    leave="ease-in duration-200"
-                    leave-from="opacity-100"
-                    leave-to="opacity-0"
-                >
-                    <div class="fixed inset-0 bg-black/75 transition-opacity" />
-                </component>
+                <x-dynamic-component
+                    :component="Splade::component('transition')"
+                    child
+                    animation="opacity"
+                    class="fixed inset-0 bg-black/75"
+                />
 
                 <div class="fixed z-30 inset-0 overflow-y-auto">
                     <div class="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
-                        <component
-                            :is="confirm.TransitionChild"
-                            as="template"
-                            enter="ease-out duration-300"
-                            enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                            enter-to="opacity-100 translate-y-0 sm:scale-100"
-                            leave="ease-in duration-200"
-                            leave-from="opacity-100 translate-y-0 sm:scale-100"
-                            leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
-                            @after-leave="confirm.emitClose"
-                        >
+                        <x-dynamic-component :component="Splade::component('transition')" child animation="fade" as="template" after-leave="confirm.emitClose">
                             <component :is="confirm.DialogPanel"
                                 class="relative bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full sm:p-6">
                                 <div class="sm:flex sm:items-start">
@@ -61,10 +45,10 @@
                                     />
                                 </div>
                             </component>
-                        </component>
+                        </x-dynamic-component>
                     </div>
                 </div>
             </component>
-        </component>
+        </x-dynamic-component>
     </template>
 </SpladeConfirm>

--- a/resources/views/data.blade.php
+++ b/resources/views/data.blade.php
@@ -1,4 +1,4 @@
-<SpladeData {!! $attributes !!}
+<SpladeData {{ $attributes }}
     @if($data) :default="@js($data)" @else :default="{!! $json !!}" @endif>
     <template #default="{!! $scope !!}">
         {{ $slot }}

--- a/resources/views/defer.blade.php
+++ b/resources/views/defer.blade.php
@@ -1,4 +1,4 @@
-<SpladeDefer {!! $attributes !!}
+<SpladeDefer {{ $attributes }}
     @if($data) :default="@js($data)" @else :default="{!! $json !!}" @endif
     @if($requestData) :request="@js($requestData)" @else :request="{!! $requestJson !!}" @endif>
     <template #default="{!! $scope !!}">

--- a/resources/views/dialog.blade.php
+++ b/resources/views/dialog.blade.php
@@ -1,0 +1,12 @@
+<SpladeDialog #default="{ Dialog, DialogPanel }">
+    <component
+        {{ $attributes
+            ->mergeVueBinding(':is', $panel ? 'DialogPanel' : 'Dialog')
+            ->mergeVueBinding(':open', $open)
+            ->mergeVueBinding(':unmount', $unmount)
+            ->mergeVueBinding('@close', $close)
+        }}
+    >
+        {{ $slot }}
+    </component>
+</SpladeDialog>

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -14,9 +14,9 @@
 
     <template #default="dropdown">
         <div class="absolute z-40">
-          <x-dynamic-component :component="Splade::component('transition')" show="dropdown.opened" >
+          <x-splade-component is="transition" show="dropdown.opened">
               {{ $slot }}
-          </x-dynamic-component>
+          </x-splade-component>
         </div>
     </template>
 </SpladeDropdown>

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -13,7 +13,7 @@
     </template>
 
     <template #default="dropdown">
-      <x-splade-transition v-bind:show="dropdown.opened" class="absolute z-40">
+      <x-splade-transition show="dropdown.opened" class="absolute z-40">
         {{ $slot }}
       </x-splade-transition>
     </template>

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -13,8 +13,8 @@
     </template>
 
     <template #default="dropdown">
-      <x-splade-transition show="dropdown.opened" class="absolute z-40">
+      <x-dynamic-component :component="Splade::component('transition')" show="dropdown.opened" class="absolute z-40">
         {{ $slot }}
-      </x-splade-transition>
+      </x-dynamic-component>
     </template>
 </SpladeDropdown>

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -13,8 +13,10 @@
     </template>
 
     <template #default="dropdown">
-      <x-dynamic-component :component="Splade::component('transition')" :unmount="false" show="dropdown.opened" class="absolute z-40">
-        {{ $slot }}
-      </x-dynamic-component>
+        <div class="absolute z-40">
+          <x-dynamic-component :component="Splade::component('transition')" show="dropdown.opened" >
+              {{ $slot }}
+          </x-dynamic-component>
+        </div>
     </template>
 </SpladeDropdown>

--- a/resources/views/dropdown.blade.php
+++ b/resources/views/dropdown.blade.php
@@ -13,7 +13,7 @@
     </template>
 
     <template #default="dropdown">
-      <x-dynamic-component :component="Splade::component('transition')" show="dropdown.opened" class="absolute z-40">
+      <x-dynamic-component :component="Splade::component('transition')" :unmount="false" show="dropdown.opened" class="absolute z-40">
         {{ $slot }}
       </x-dynamic-component>
     </template>

--- a/resources/views/event.blade.php
+++ b/resources/views/event.blade.php
@@ -1,4 +1,4 @@
-<SpladeEvent :listeners='@json($listeners)' {!! $attributes !!}>
+<SpladeEvent :listeners='@json($listeners)' {{ $attributes }}>
     <template #default="{!! $scope !!}">
         {{ $slot }}
     </template>

--- a/resources/views/form.blade.php
+++ b/resources/views/form.blade.php
@@ -1,12 +1,12 @@
 @php $data = $formData() @endphp
 
-<SpladeForm {!! $attributes->except('class') !!}
+<SpladeForm {{ $attributes->except('class') }}
     @if($data['data']) :default="@js($data['data'])" @else :default="{!! $data['json'] !!}" @endif
     :splade-id="@js($spladeId)"
 >
     <template #default="{!! $scope !!}">
-        <form data-splade-id="{{ $spladeId }}" v-bind="form.$attrs" @submit.prevent="form.submit" {!! $attributes->only(['action', 'method'])->merge(['method' => 'POST']) !!}>
-            <fieldset v-bind:disabled="form.processing" {!! $attributes->only('class') !!}>
+        <form data-splade-id="{{ $spladeId }}" v-bind="form.$attrs" @submit.prevent="form.submit" {{ $attributes->only(['action', 'method'])->merge(['method' => 'POST']) }}>
+            <fieldset v-bind:disabled="form.processing" {{ $attributes->only('class') }}>
                 {{ $slot }}
             </fieldset>
         </form>

--- a/resources/views/form/checkboxes.blade.php
+++ b/resources/views/form/checkboxes.blade.php
@@ -1,10 +1,10 @@
-<x-dynamic-component :component="Splade::component('group')" :name="$name" :label="$label" :inline="$inline" :help="$help">
+<x-splade-component is="group" :name="$name" :label="$label" :inline="$inline" :help="$help">
     @foreach($options as $value => $label)
-        <x-dynamic-component
-            :component="Splade::component('checkbox')"
+        <x-splade-component
+            is="checkbox"
             :name="$name . '[]'"
             :validation-key="$name . '.' . $loop->index"
             :label="$label"
             :value="$value" />
     @endforeach
-</x-dynamic-component>
+</x-splade-component>

--- a/resources/views/form/checkboxes.blade.php
+++ b/resources/views/form/checkboxes.blade.php
@@ -1,7 +1,7 @@
-<x-dynamic-component :component="$groupComponent" :name="$name" :label="$label" :inline="$inline" :help="$help">
+<x-dynamic-component :component="Splade::component('group')" :name="$name" :label="$label" :inline="$inline" :help="$help">
     @foreach($options as $value => $label)
         <x-dynamic-component
-            :component="$checkboxComponent"
+            :component="Splade::component('checkbox')"
             :name="$name . '[]'"
             :validation-key="$name . '.' . $loop->index"
             :label="$label"

--- a/resources/views/form/radios.blade.php
+++ b/resources/views/form/radios.blade.php
@@ -1,5 +1,5 @@
-<x-dynamic-component :component="Splade::component('group')" :name="$name" :label="$label" :inline="$inline" :help="$help">
+<x-splade-component is="group" :name="$name" :label="$label" :inline="$inline" :help="$help">
     @foreach($options as $value => $label)
-        <x-dynamic-component :component="Splade::component('radio')" :name="$name" :label="$label" :value="$value" />
+        <x-splade-component is="radio" :name="$name" :label="$label" :value="$value" />
     @endforeach
-</x-dynamic-component>
+</x-splade-component>

--- a/resources/views/form/radios.blade.php
+++ b/resources/views/form/radios.blade.php
@@ -1,5 +1,5 @@
-<x-dynamic-component :component="$groupComponent" :name="$name" :label="$label" :inline="$inline" :help="$help">
+<x-dynamic-component :component="Splade::component('group')" :name="$name" :label="$label" :inline="$inline" :help="$help">
     @foreach($options as $value => $label)
-        <x-dynamic-component :component="$radioComponent" :name="$name" :label="$label" :value="$value" />
+        <x-dynamic-component :component="Splade::component('radio')" :name="$name" :label="$label" :value="$value" />
     @endforeach
 </x-dynamic-component>

--- a/resources/views/modal-wrapper.blade.php
+++ b/resources/views/modal-wrapper.blade.php
@@ -16,7 +16,7 @@
                 >
                     <div
                         v-show="modal.onTopOfStack"
-                        class="fixed inset-0 bg-black/75 transition-opacity"
+                        class="fixed inset-0 bg-black/75"
                     />
                 </component>
 

--- a/resources/views/modal-wrapper.blade.php
+++ b/resources/views/modal-wrapper.blade.php
@@ -1,7 +1,7 @@
 <!--START-SPLADE-MODAL-{{ $key }}-->
 <SpladeModal {{ $baseAttributes->mergeVueBinding(':close-button', $closeButton) }}>
     <template #default="modal">
-        <x-dynamic-component :component="Splade::component('transition')" show="modal.isOpen">
+        <x-splade-component is="transition" show="modal.isOpen">
             <component :dusk="`modal.${modal.stack}`" :is="modal.Dialog" @close="modal.setIsOpen" class="relative z-20">
                 <!-- The backdrop, rendered as a fixed sibling to the panel container -->
                 <component
@@ -21,7 +21,7 @@
 
                 {{ $slot }}
             </component>
-        </x-dynamic-component>
+        </x-splade-component>
     </template>
 </SpladeModal>
 <!--END-SPLADE-MODAL-{{ $key }}-->

--- a/resources/views/modal-wrapper.blade.php
+++ b/resources/views/modal-wrapper.blade.php
@@ -1,5 +1,5 @@
 <!--START-SPLADE-MODAL-{{ $key }}-->
-<SpladeModal {{ $baseAttributes }} v-bind:close-button="@js($closeButton)">
+<SpladeModal {{ $baseAttributes->mergeVueBinding(':close-button', $closeButton) }}>
     <template #default="modal">
         <component :dusk="`modal.${modal.stack}`" :is="modal.TransitionRoot" appear as="template" :show="modal.isOpen">
             <component :is="modal.Dialog" as="div" @close="modal.setIsOpen" class="relative z-20">

--- a/resources/views/modal-wrapper.blade.php
+++ b/resources/views/modal-wrapper.blade.php
@@ -1,11 +1,11 @@
 <!--START-SPLADE-MODAL-{{ $key }}-->
 <SpladeModal {{ $baseAttributes->mergeVueBinding(':close-button', $closeButton) }}>
     <template #default="modal">
-        <component :dusk="`modal.${modal.stack}`" :is="modal.TransitionRoot" appear as="template" :show="modal.isOpen">
-            <component :is="modal.Dialog" as="div" @close="modal.setIsOpen" class="relative z-20">
+        <x-dynamic-component :component="Splade::component('transition')" as="template" show="modal.isOpen">
+            <component :dusk="`modal.${modal.stack}`" :is="modal.Dialog" as="div" @close="modal.setIsOpen" class="relative z-20">
                 <!-- The backdrop, rendered as a fixed sibling to the panel container -->
                 <component
-                    :is="modal.stack === 1 && modal.onTopOfStack ? modal.TransitionChild : 'div'"
+                    :is="modal.stack === 1 ? modal.TransitionChild : 'div'"
                     as="template"
                     enter="ease-in-out duration-300"
                     enter-from="opacity-0"
@@ -22,7 +22,7 @@
 
                 {{ $slot }}
             </component>
-        </component>
+        </x-dynamic-component>
     </template>
 </SpladeModal>
 <!--END-SPLADE-MODAL-{{ $key }}-->

--- a/resources/views/modal-wrapper.blade.php
+++ b/resources/views/modal-wrapper.blade.php
@@ -2,25 +2,19 @@
 <SpladeModal {{ $baseAttributes->mergeVueBinding(':close-button', $closeButton) }}>
     <template #default="modal">
         <x-splade-component is="transition" show="modal.isOpen">
-            <component :dusk="`modal.${modal.stack}`" :is="modal.Dialog" @close="modal.setIsOpen" class="relative z-20">
+            <x-splade-component is="dialog" v-bind:dusk="`modal.${modal.stack}`" close="modal.setIsOpen" class="relative z-20">
                 <!-- The backdrop, rendered as a fixed sibling to the panel container -->
-                <component
-                    :is="modal.stack === 1 ? modal.TransitionChild : 'div'"
-                    enter="ease-in-out duration-300"
-                    enter-from="opacity-0"
-                    enter-to="opacity-100"
-                    leave="ease-in-out duration-300"
-                    leave-from="opacity-100"
-                    leave-to="opacity-0"
-                >
-                    <div
-                        v-show="modal.onTopOfStack"
-                        class="fixed inset-0 bg-black/75"
-                    />
-                </component>
+                <x-splade-component
+                    is="transition" child
+                    v-if="modal.stack === 1"
+                    animation="opacity">
+                    <div v-show="modal.onTopOfStack" class="fixed inset-0 bg-black/75" />
+                </x-splade-component>
+
+                <div v-if="modal.stack > 1 && modal.onTopOfStack" class="fixed inset-0 bg-black/75" />
 
                 {{ $slot }}
-            </component>
+            </x-splade-component>
         </x-splade-component>
     </template>
 </SpladeModal>

--- a/resources/views/modal-wrapper.blade.php
+++ b/resources/views/modal-wrapper.blade.php
@@ -1,12 +1,11 @@
 <!--START-SPLADE-MODAL-{{ $key }}-->
 <SpladeModal {{ $baseAttributes->mergeVueBinding(':close-button', $closeButton) }}>
     <template #default="modal">
-        <x-dynamic-component :component="Splade::component('transition')" as="template" show="modal.isOpen">
-            <component :dusk="`modal.${modal.stack}`" :is="modal.Dialog" as="div" @close="modal.setIsOpen" class="relative z-20">
+        <x-dynamic-component :component="Splade::component('transition')" show="modal.isOpen">
+            <component :dusk="`modal.${modal.stack}`" :is="modal.Dialog" @close="modal.setIsOpen" class="relative z-20">
                 <!-- The backdrop, rendered as a fixed sibling to the panel container -->
                 <component
                     :is="modal.stack === 1 ? modal.TransitionChild : 'div'"
-                    as="template"
                     enter="ease-in-out duration-300"
                     enter-from="opacity-0"
                     enter-to="opacity-100"

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -4,10 +4,8 @@
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-center">
             <!-- The actual dialog panel -->
-            <x-splade-component is="transition" child as="template" animation="fade" after-leave="modal.emitClose">
-                <component :is="modal.DialogPanel"
-                    class="transition w-full"
-                    :class="{
+            <x-splade-component is="transition" child animation="fade" after-leave="modal.emitClose">
+                <x-splade-component is="dialog" panel class="transition w-full" v-bind:class="{
                         'blur-sm': !modal.onTopOfStack,
                         'sm:max-w-sm': modal.maxWidth == 'sm',
                         'sm:max-w-md': modal.maxWidth == 'md',
@@ -32,7 +30,7 @@
                         </div>
                         {{ $slot }}
                     </div>
-                </component>
+                </x-splade-component>
             </x-splade-component>
         </div>
     </div>

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -1,10 +1,10 @@
-<x-dynamic-component :component="Splade::component('modal-wrapper')" :base-attributes="$attributes" :key="$modalKey" :close-button="$closeButton">
+<x-splade-component is="modal-wrapper" :base-attributes="$attributes" :key="$modalKey" :close-button="$closeButton">
     <!-- Full-screen scrollable container -->
     <div class="fixed inset-0 overflow-y-auto p-4">
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-center">
             <!-- The actual dialog panel -->
-            <x-dynamic-component :component="Splade::component('transition')" child as="template" animation="fade" after-leave="modal.emitClose">
+            <x-splade-component is="transition" child as="template" animation="fade" after-leave="modal.emitClose">
                 <component :is="modal.DialogPanel"
                     class="transition w-full"
                     :class="{
@@ -33,7 +33,7 @@
                         {{ $slot }}
                     </div>
                 </component>
-            </x-dynamic-component>
+            </x-splade-component>
         </div>
     </div>
-</x-dynamic-component>
+</x-splade-component>

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -4,7 +4,7 @@
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-center">
             <!-- The actual dialog panel -->
-            <x-dynamic-component :component="Splade::component('transition')" child as="template" animation="defaultInOut" after-leave="modal.emitClose">
+            <x-dynamic-component :component="Splade::component('transition')" child as="template" animation="fade" after-leave="modal.emitClose">
                 <component :is="modal.DialogPanel"
                     class="transition w-full"
                     :class="{

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -1,19 +1,10 @@
-<x-dynamic-component :component="$wrapperName" :base-attributes="$attributes" :key="$modalKey" :close-button="$closeButton">
+<x-dynamic-component :component="Splade::component('modal-wrapper')" :base-attributes="$attributes" :key="$modalKey" :close-button="$closeButton">
     <!-- Full-screen scrollable container -->
     <div class="fixed inset-0 overflow-y-auto p-4">
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-center">
             <!-- The actual dialog panel -->
-            <component :is="modal.TransitionChild"
-                as="template"
-                enter="transform transition ease-in-out duration-300"
-                enter-from="opacity-0 scale-95"
-                enter-to="opacity-100 scale-100"
-                leave="transform transition ease-in-out duration-300"
-                leave-from="opacity-100 scale-100"
-                leave-to="opacity-0 scale-95"
-                @after-leave="modal.emitClose"
-            >
+            <x-dynamic-component :component="Splade::component('transition')" as="template" animation="defaultInOut" after-leave="modal.emitClose">
                 <component :is="modal.DialogPanel"
                     class="transition w-full"
                     :class="{
@@ -42,7 +33,7 @@
                         {{ $slot }}
                     </div>
                 </component>
-            </component>
+            </x-dynamic-component>
         </div>
     </div>
 </x-dynamic-component>

--- a/resources/views/modal.blade.php
+++ b/resources/views/modal.blade.php
@@ -4,7 +4,7 @@
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-center">
             <!-- The actual dialog panel -->
-            <x-dynamic-component :component="Splade::component('transition')" as="template" animation="defaultInOut" after-leave="modal.emitClose">
+            <x-dynamic-component :component="Splade::component('transition')" child as="template" animation="defaultInOut" after-leave="modal.emitClose">
                 <component :is="modal.DialogPanel"
                     class="transition w-full"
                     :class="{

--- a/resources/views/slideover.blade.php
+++ b/resources/views/slideover.blade.php
@@ -4,16 +4,7 @@
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-end">
             <!-- The actual dialog panel -->
-            <component :is="modal.TransitionChild"
-                as="template"
-                enter="transform transition ease-in-out duration-300"
-                enter-from="translate-x-full"
-                enter-to="translate-x-0"
-                leave="transform transition ease-in-out duration-300"
-                leave-from="translate-x-0"
-                leave-to="translate-x-full"
-                @after-leave="modal.emitClose"
-            >
+            <x-dynamic-component :component="Splade::component('transition')" child as="template" animation="fromRight" after-leave="modal.emitClose">
                 <component :is="modal.DialogPanel"
                     class="transition w-full"
                     :class="{
@@ -43,7 +34,7 @@
                         {{ $slot }}
                     </div>
                 </component>
-            </component>
+            </x-dynamic-component>
         </div>
     </div>
 </x-dynamic-component>

--- a/resources/views/slideover.blade.php
+++ b/resources/views/slideover.blade.php
@@ -4,23 +4,20 @@
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-end">
             <!-- The actual dialog panel -->
-            <x-splade-component is="transition" child as="template" animation="slideRight" after-leave="modal.emitClose">
-                <component :is="modal.DialogPanel"
-                    class="transition w-full"
-                    :class="{
-                        'blur-sm': !modal.onTopOfStack,
-                        'sm:max-w-sm': modal.maxWidth == 'sm',
-                        'sm:max-w-md': modal.maxWidth == 'md',
-                        'sm:max-w-md md:max-w-lg': modal.maxWidth == 'lg',
-                        'sm:max-w-md md:max-w-xl': modal.maxWidth == 'xl',
-                        'sm:max-w-md md:max-w-xl lg:max-w-2xl': modal.maxWidth == '2xl',
-                        'sm:max-w-md md:max-w-xl lg:max-w-3xl': modal.maxWidth == '3xl',
-                        'sm:max-w-md md:max-w-xl lg:max-w-3xl xl:max-w-4xl': modal.maxWidth == '4xl',
-                        'sm:max-w-md md:max-w-xl lg:max-w-3xl xl:max-w-5xl': modal.maxWidth == '5xl',
-                        'sm:max-w-md md:max-w-xl lg:max-w-3xl xl:max-w-5xl 2xl:max-w-6xl': modal.maxWidth == '6xl',
-                        'sm:max-w-md md:max-w-xl lg:max-w-3xl xl:max-w-5xl 2xl:max-w-7xl': modal.maxWidth == '7xl'
-                    }"
-                >
+            <x-splade-component is="transition" child animation="slideRight" after-leave="modal.emitClose">
+                <x-splade-component is="dialog" panel class="transition w-full" v-bind:class="{
+                    'blur-sm': !modal.onTopOfStack,
+                    'sm:max-w-sm': modal.maxWidth == 'sm',
+                    'sm:max-w-md': modal.maxWidth == 'md',
+                    'sm:max-w-md md:max-w-lg': modal.maxWidth == 'lg',
+                    'sm:max-w-md md:max-w-xl': modal.maxWidth == 'xl',
+                    'sm:max-w-md md:max-w-xl lg:max-w-2xl': modal.maxWidth == '2xl',
+                    'sm:max-w-md md:max-w-xl lg:max-w-3xl': modal.maxWidth == '3xl',
+                    'sm:max-w-md md:max-w-xl lg:max-w-3xl xl:max-w-4xl': modal.maxWidth == '4xl',
+                    'sm:max-w-md md:max-w-xl lg:max-w-3xl xl:max-w-5xl': modal.maxWidth == '5xl',
+                    'sm:max-w-md md:max-w-xl lg:max-w-3xl xl:max-w-5xl 2xl:max-w-6xl': modal.maxWidth == '6xl',
+                    'sm:max-w-md md:max-w-xl lg:max-w-3xl xl:max-w-5xl 2xl:max-w-7xl': modal.maxWidth == '7xl'
+                }">
                     <div class="bg-white p-6 min-h-screen relative">
                         <div v-if="modal.closeButton" class="absolute top-0 right-0 pt-3 pr-3">
                             <button dusk="close-modal-button" @click="modal.close" type="button" class="text-gray-400 hover:text-gray-500">
@@ -33,7 +30,7 @@
 
                         {{ $slot }}
                     </div>
-                </component>
+                </x-splade-component>
             </x-splade-component>
         </div>
     </div>

--- a/resources/views/slideover.blade.php
+++ b/resources/views/slideover.blade.php
@@ -4,7 +4,7 @@
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-end">
             <!-- The actual dialog panel -->
-            <x-splade-component is="transition" child animation="slideRight" after-leave="modal.emitClose">
+            <x-splade-component is="transition" child animation="slide-right" after-leave="modal.emitClose">
                 <x-splade-component is="dialog" panel class="transition w-full" v-bind:class="{
                     'blur-sm': !modal.onTopOfStack,
                     'sm:max-w-sm': modal.maxWidth == 'sm',

--- a/resources/views/slideover.blade.php
+++ b/resources/views/slideover.blade.php
@@ -1,4 +1,4 @@
-<x-dynamic-component :component="$wrapperName" :base-attributes="$attributes" :key="$modalKey" :close-button="$closeButton">
+<x-dynamic-component :component="Splade::component('modal-wrapper')" :base-attributes="$attributes" :key="$modalKey" :close-button="$closeButton">
     <!-- Full-screen scrollable container -->
     <div class="fixed inset-0 overflow-y-auto">
         <!-- Container to center the panel -->

--- a/resources/views/slideover.blade.php
+++ b/resources/views/slideover.blade.php
@@ -1,10 +1,10 @@
-<x-dynamic-component :component="Splade::component('modal-wrapper')" :base-attributes="$attributes" :key="$modalKey" :close-button="$closeButton">
+<x-splade-component is="modal-wrapper" :base-attributes="$attributes" :key="$modalKey" :close-button="$closeButton">
     <!-- Full-screen scrollable container -->
     <div class="fixed inset-0 overflow-y-auto">
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-end">
             <!-- The actual dialog panel -->
-            <x-dynamic-component :component="Splade::component('transition')" child as="template" animation="slideRight" after-leave="modal.emitClose">
+            <x-splade-component is="transition" child as="template" animation="slideRight" after-leave="modal.emitClose">
                 <component :is="modal.DialogPanel"
                     class="transition w-full"
                     :class="{
@@ -34,7 +34,7 @@
                         {{ $slot }}
                     </div>
                 </component>
-            </x-dynamic-component>
+            </x-splade-component>
         </div>
     </div>
-</x-dynamic-component>
+</x-splade-component>

--- a/resources/views/slideover.blade.php
+++ b/resources/views/slideover.blade.php
@@ -4,7 +4,7 @@
         <!-- Container to center the panel -->
         <div class="flex min-h-full items-center justify-end">
             <!-- The actual dialog panel -->
-            <x-dynamic-component :component="Splade::component('transition')" child as="template" animation="fromRight" after-leave="modal.emitClose">
+            <x-dynamic-component :component="Splade::component('transition')" child as="template" animation="slideRight" after-leave="modal.emitClose">
                 <component :is="modal.DialogPanel"
                     class="transition w-full"
                     :class="{

--- a/resources/views/table/add-search-row.blade.php
+++ b/resources/views/table/add-search-row.blade.php
@@ -1,4 +1,4 @@
-<x-dynamic-component :component="Splade::component('button-with-dropdown')" dusk="add-search-row-dropdown">
+<x-splade-component is="button-with-dropdown" dusk="add-search-row-dropdown">
     <x-slot:button>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
@@ -17,4 +17,4 @@
             {{ $searchInput->label }}
         </button>
     @endforeach
-</x-dynamic-component>
+</x-splade-component>

--- a/resources/views/table/add-search-row.blade.php
+++ b/resources/views/table/add-search-row.blade.php
@@ -1,4 +1,4 @@
-<x-splade-button-with-dropdown dusk="add-search-row-dropdown">
+<x-dynamic-component :component="Splade::component('button-with-dropdown')" dusk="add-search-row-dropdown">
     <x-slot:button>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
             <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />
@@ -17,4 +17,4 @@
             {{ $searchInput->label }}
         </button>
     @endforeach
-</x-splade-button-with-dropdown>
+</x-dynamic-component>

--- a/resources/views/table/columns.blade.php
+++ b/resources/views/table/columns.blade.php
@@ -24,7 +24,7 @@
 
                     <button
                         type="button"
-                        class="ml-4 relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-light-blue-500"
+                        class="ml-4 relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-light-blue-500"
                         :class="{
                             'bg-green-500': table.columnIsVisible(@js($column->key)),
                             'bg-gray-200': !table.columnIsVisible(@js($column->key)),
@@ -42,7 +42,7 @@
                                 'translate-x-5': table.columnIsVisible(@js($column->key)),
                                 'translate-x-0': !table.columnIsVisible(@js($column->key)),
                             }"
-                            class="inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200" />
+                            class="inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-300" />
                     </button>
                 </li>
             @endforeach

--- a/resources/views/table/columns.blade.php
+++ b/resources/views/table/columns.blade.php
@@ -1,4 +1,4 @@
-<x-splade-button-with-dropdown dusk="columns-dropdown">
+<x-dynamic-component :component="Splade::component('button-with-dropdown')" dusk="columns-dropdown">
     <x-slot:button>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"
             :class="{
@@ -48,4 +48,4 @@
             @endforeach
         </ul>
     </div>
-</x-splade-button-with-dropdown>
+</x-dynamic-component>

--- a/resources/views/table/columns.blade.php
+++ b/resources/views/table/columns.blade.php
@@ -1,4 +1,4 @@
-<x-dynamic-component :component="Splade::component('button-with-dropdown')" dusk="columns-dropdown">
+<x-splade-component is="button-with-dropdown" dusk="columns-dropdown">
     <x-slot:button>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"
             :class="{
@@ -48,4 +48,4 @@
             @endforeach
         </ul>
     </div>
-</x-dynamic-component>
+</x-splade-component>

--- a/resources/views/table/filters.blade.php
+++ b/resources/views/table/filters.blade.php
@@ -1,4 +1,4 @@
-<x-dynamic-component :component="Splade::component('button-with-dropdown')" dusk="filters-dropdown">
+<x-splade-component is="button-with-dropdown" dusk="filters-dropdown">
     <x-slot:button>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"
             :class="{
@@ -39,4 +39,4 @@
             </div>
         @endforeach
     </div>
-</x-dynamic-component>
+</x-splade-component>

--- a/resources/views/table/filters.blade.php
+++ b/resources/views/table/filters.blade.php
@@ -1,4 +1,4 @@
-<x-splade-button-with-dropdown dusk="filters-dropdown">
+<x-dynamic-component :component="Splade::component('button-with-dropdown')" dusk="filters-dropdown">
     <x-slot:button>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"
             :class="{
@@ -39,5 +39,4 @@
             </div>
         @endforeach
     </div>
-
-</x-splade-button-with-dropdown>
+</x-dynamic-component>

--- a/resources/views/table/table.blade.php
+++ b/resources/views/table/table.blade.php
@@ -13,7 +13,7 @@
                 @includeUnless($searchInput->key === 'global', 'splade::table.search-row')
             @endforeach
 
-            <x-dynamic-component :component="$wrapperName">
+            <x-dynamic-component :component="Splade::component('table-wrapper')">
                 <table class="min-w-full divide-y divide-gray-200 bg-white">
                     @isset($head)
                         {{ $head }}

--- a/resources/views/table/table.blade.php
+++ b/resources/views/table/table.blade.php
@@ -1,10 +1,10 @@
-<SpladeTable {!! $attributes->except('class') !!}
+<SpladeTable {{ $attributes->except('class') }}
     :striped="@js($striped)"
     :columns="@js($table->columns())"
     :default-visible-toggleable-columns="@js($table->defaultVisibleToggleableColumns())"
 >
     <template #default="{!! $scope !!}">
-        <div {!! $attributes->only('class') !!}>
+        <div {{ $attributes->only('class') }}>
             @if($hasControls())
                 @include('splade::table.controls')
             @endif

--- a/resources/views/table/table.blade.php
+++ b/resources/views/table/table.blade.php
@@ -13,7 +13,7 @@
                 @includeUnless($searchInput->key === 'global', 'splade::table.search-row')
             @endforeach
 
-            <x-dynamic-component :component="Splade::component('table-wrapper')">
+            <x-splade-component is="table-wrapper">
                 <table class="min-w-full divide-y divide-gray-200 bg-white">
                     @isset($head)
                         {{ $head }}
@@ -27,7 +27,7 @@
                         @include('splade::table.body')
                     @endisset
                 </table>
-            </x-dynamic-component>
+            </x-splade-component>
 
             @if($isPaginated())
                 {{ $table->resource->links($paginationView, ['table' => $table]) }}

--- a/resources/views/toast-wrapper.blade.php
+++ b/resources/views/toast-wrapper.blade.php
@@ -1,19 +1,8 @@
 <SpladeToasts>
     <template #default="toasts">
-        <component :is="toasts.TransitionRoot" appear :show="toasts.hasBackdrop">
-            <!-- The backdrop, rendered as a fixed sibling to the panel container -->
-            <component
-                :is="toasts.TransitionChild"
-                enter="ease-in-out duration-300"
-                enter-from="opacity-0"
-                enter-to="opacity-100"
-                leave="ease-in-out duration-300"
-                leave-from="opacity-100"
-                leave-to="opacity-0"
-            >
-                <div class="fixed inset-0 bg-black/75 transition-opacity" />
-            </component>
-        </component>
+        <x-dynamic-component :component="Splade::component('transition')" animation="opacity" appear show="toasts.hasBackdrop">
+            <div class="fixed inset-0 bg-black/75" />
+        </x-dynamic-component>
 
         <div class="fixed inset-0 grid grid-cols-3 grid-flow-row-3 z-10 pointer-events-none">
             <div v-for="position in toasts.positions" class="relative">

--- a/resources/views/toast-wrapper.blade.php
+++ b/resources/views/toast-wrapper.blade.php
@@ -1,7 +1,7 @@
 <SpladeToasts>
     <template #default="toasts">
-        <x-dynamic-component
-            :component="Splade::component('transition')"
+        <x-splade-component
+            is="transition"
             animation="opacity"
             appear
             show="toasts.hasBackdrop"

--- a/resources/views/toast-wrapper.blade.php
+++ b/resources/views/toast-wrapper.blade.php
@@ -1,8 +1,12 @@
 <SpladeToasts>
     <template #default="toasts">
-        <x-dynamic-component :component="Splade::component('transition')" animation="opacity" appear show="toasts.hasBackdrop">
-            <div class="fixed inset-0 bg-black/75" />
-        </x-dynamic-component>
+        <x-dynamic-component
+            :component="Splade::component('transition')"
+            animation="opacity"
+            appear
+            show="toasts.hasBackdrop"
+            class="fixed inset-0 bg-black/75"
+        />
 
         <div class="fixed inset-0 grid grid-cols-3 grid-flow-row-3 z-10 pointer-events-none">
             <div v-for="position in toasts.positions" class="relative">

--- a/resources/views/toast-wrapper.blade.php
+++ b/resources/views/toast-wrapper.blade.php
@@ -26,7 +26,7 @@
                 >
                     <template v-for="(toast, toastKey) in toasts.toasts">
                         <template v-if="toast.position == position && !toast.dismissed && toast.html">
-                            <component :is="toasts.Render"
+                            <SpladeRender
                                 @dismiss="toasts.dismissToast(toastKey)"
                                 :toast-key="toastKey"
                                 :key="toastKey"

--- a/resources/views/toast.blade.php
+++ b/resources/views/toast.blade.php
@@ -1,7 +1,7 @@
 
 <SpladeToast v-bind:auto-dismiss="@json($autoDismiss)" #default="toast">
-  <x-dynamic-component :component="Splade::component('transition')" appear show="toast.show">
-    <x-dynamic-component :component="Splade::component('transition')" child after-leave="toast.emitDismiss">
+  <x-splade-component is="transition" appear show="toast.show">
+    <x-splade-component is="transition" child after-leave="toast.emitDismiss">
       <div @class([
         'p-4 pointer-events-auto border-l-4 shadow-md min-w-[240px]',
         'bg-green-50 border-green-400' => $isSuccess,
@@ -72,6 +72,6 @@
           </div>
         </div>
       </div>
-    </x-dynamic-component>
-  </x-dynamic-component>
+    </x-splade-component>
+  </x-splade-component>
 </SpladeToast>

--- a/resources/views/toast.blade.php
+++ b/resources/views/toast.blade.php
@@ -1,16 +1,7 @@
 
 <SpladeToast v-bind:auto-dismiss="@json($autoDismiss)" #default="toast">
-  <component :is="toast.TransitionRoot" appear :show="toast.show">
-    <component
-        :is="toast.TransitionChild"
-        enter="ease-in-out duration-300"
-        enter-from="opacity-0 scale-95"
-        enter-to="opacity-100 scale-100"
-        leave="ease-in-out duration-300"
-        leave-from="opacity-100 scale-100"
-        leave-to="opacity-0 scale-95"
-        @after-leave="toast.emitDismiss"
-    >
+  <x-dynamic-component :component="Splade::component('transition')" appear show="toast.show">
+    <x-dynamic-component :component="Splade::component('transition')" child after-leave="toast.emitDismiss">
       <div @class([
         'p-4 pointer-events-auto border-l-4 shadow-md min-w-[240px]',
         'bg-green-50 border-green-400' => $isSuccess,
@@ -81,6 +72,6 @@
           </div>
         </div>
       </div>
-    </component>
-  </component>
+    </x-dynamic-component>
+  </x-dynamic-component>
 </SpladeToast>

--- a/resources/views/transition.blade.php
+++ b/resources/views/transition.blade.php
@@ -1,8 +1,8 @@
-<SpladeTransition #default="{!! $scope !!}">
+<SpladeTransition #default="{ TransitionRoot, TransitionChild }">
     <component
         {{ $attributes
             ->merge($animation->toArray())
-            ->mergeVueBinding(':is', $child ? 'transition.TransitionChild' : 'transition.TransitionRoot')
+            ->mergeVueBinding(':is', $child ? 'TransitionChild' : 'TransitionRoot')
             ->mergeVueBinding(':show', $show)
             ->mergeVueBinding(':appear', $appear)
             ->mergeVueBinding(':unmount', $unmount)

--- a/resources/views/transition.blade.php
+++ b/resources/views/transition.blade.php
@@ -1,17 +1,13 @@
 @php $transitionAttributes = [':show', 'v-bind:show', 'enter', 'enter-from', 'enter-to', 'leave', 'leave-from', 'leave-to'] @endphp
 
-<div {{ $attributes->except($transitionAttributes) }}>
+<div {{ $attributes->only($transitionAttributes) }}>
     <SpladeTransition #default="{!! $scope !!}">
         <component
             as="div"
             :is="transition.TransitionRoot"
             {{ $attributes->only($transitionAttributes)->merge([
-                'enter' => 'transition ease-out duration-200',
-                'enter-from' => 'opacity-0 scale-95',
-                'enter-to' => 'opacity-100 scale-100',
-                'leave' => 'transition ease-in duration-200',
-                'leave-from' => 'opacity-100 scale-100',
-                'leave-to' => 'opacity-0 scale-95',
+                ':show' => $show,
+                ...$animation->toArray()
             ]) }}
         >
             {{ $slot }}

--- a/resources/views/transition.blade.php
+++ b/resources/views/transition.blade.php
@@ -1,16 +1,13 @@
-@php $transitionAttributes = [':show', 'v-bind:show', 'enter', 'enter-from', 'enter-to', 'leave', 'leave-from', 'leave-to'] @endphp
-
-<div {{ $attributes->only($transitionAttributes) }}>
-    <SpladeTransition #default="{!! $scope !!}">
-        <component
-            as="div"
-            :is="transition.TransitionRoot"
-            {{ $attributes->only($transitionAttributes)->merge([
-                ':show' => $show,
-                ...$animation->toArray()
-            ]) }}
-        >
-            {{ $slot }}
-        </component>
-    </SpladeTransition>
-</div>
+<SpladeTransition #default="{!! $scope !!}">
+    <component
+        {{ $attributes
+            ->merge($animation->toArray())
+            ->mergeVueBinding(':is', $child ? 'transition.TransitionChild' : 'transition.TransitionRoot')
+            ->mergeVueBinding(':show', $show)
+            ->mergeVueBinding(':appear', $appear)
+            ->mergeVueBinding('@after-leave', $afterLeave)
+        }}
+    >
+        {{ $slot }}
+    </component>
+</SpladeTransition>

--- a/resources/views/transition.blade.php
+++ b/resources/views/transition.blade.php
@@ -5,6 +5,7 @@
             ->mergeVueBinding(':is', $child ? 'transition.TransitionChild' : 'transition.TransitionRoot')
             ->mergeVueBinding(':show', $show)
             ->mergeVueBinding(':appear', $appear)
+            ->mergeVueBinding(':unmount', $unmount)
             ->mergeVueBinding('@after-leave', $afterLeave)
         }}
     >

--- a/resources/views/transitions/classes.blade.php
+++ b/resources/views/transitions/classes.blade.php
@@ -1,0 +1,3 @@
+<div class='duration-200 duration-300 ease-in ease-in-out ease-out opacity-0 opacity-100 scale-100 scale-95 transform transition translate-x-0 translate-x-full'>
+<!-- This is a dummy template so Tailwind won't purge these transition classes. -->
+</div>

--- a/resources/views/transitions/classes.blade.php
+++ b/resources/views/transitions/classes.blade.php
@@ -1,3 +1,3 @@
-<div class='duration-200 duration-300 ease-in ease-in-out ease-out opacity-0 opacity-100 scale-100 scale-95 sm:scale-100 sm:scale-95 sm:translate-y-0 transform transition translate-x-0 translate-x-full translate-y-0 translate-y-4'>
+<div class='duration-300 ease-in-out opacity-0 opacity-100 scale-100 scale-95 sm:scale-100 sm:scale-95 sm:translate-y-0 transform transition translate-x-0 translate-x-full translate-y-0 translate-y-4'>
 <!-- This is an automatically generated template so that Tailwind won't purge these transition classes... -->
 </div>

--- a/resources/views/transitions/classes.blade.php
+++ b/resources/views/transitions/classes.blade.php
@@ -1,3 +1,3 @@
-<div class='duration-200 duration-300 ease-in ease-in-out ease-out opacity-0 opacity-100 scale-100 scale-95 transform transition translate-x-0 translate-x-full'>
-<!-- This is a dummy template so Tailwind won't purge these transition classes. -->
+<div class='duration-200 duration-300 ease-in ease-in-out ease-out opacity-0 opacity-100 scale-100 scale-95 sm:scale-100 sm:scale-95 sm:translate-y-0 transform transition translate-x-0 translate-x-full translate-y-0 translate-y-4'>
+<!-- This is an automatically generated template so that Tailwind won't purge these transition classes... -->
 </div>

--- a/src/Components/ButtonWithDropdown.php
+++ b/src/Components/ButtonWithDropdown.php
@@ -22,14 +22,6 @@ class ButtonWithDropdown extends Component
      */
     public function render()
     {
-        $prefix = config('splade.blade.component_prefix');
-
-        if ($prefix) {
-            $prefix .= '-';
-        }
-
-        return view('splade::button-with-dropdown', [
-            'wrapperName' => $prefix . 'dropdown',
-        ]);
+        return view('splade::button-with-dropdown');
     }
 }

--- a/src/Components/Dialog.php
+++ b/src/Components/Dialog.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ProtoneMedia\Splade\Components;
+
+use Illuminate\View\Component;
+
+class Dialog extends Component
+{
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        private string $open = '',
+        private bool $unmount = true,
+        private bool $panel = false,
+        private string $close = '',
+    ) {
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return view('splade::dialog', [
+            'panel'   => $this->panel,
+            'open'    => $this->open,
+            'unmount' => $this->unmount,
+            'close'   => $this->close,
+        ]);
+    }
+}

--- a/src/Components/Form/Checkboxes.php
+++ b/src/Components/Form/Checkboxes.php
@@ -36,15 +36,6 @@ class Checkboxes extends Component
      */
     public function render()
     {
-        $prefix = config('splade.blade.component_prefix');
-
-        if ($prefix) {
-            $prefix .= '-';
-        }
-
-        return view('splade::form.checkboxes', [
-            'groupComponent'    => $prefix . 'group',
-            'checkboxComponent' => $prefix . 'checkbox',
-        ]);
+        return view('splade::form.checkboxes');
     }
 }

--- a/src/Components/Form/Radios.php
+++ b/src/Components/Form/Radios.php
@@ -31,15 +31,6 @@ class Radios extends Component
      */
     public function render()
     {
-        $prefix = config('splade.blade.component_prefix');
-
-        if ($prefix) {
-            $prefix .= '-';
-        }
-
-        return view('splade::form.radios', [
-            'groupComponent' => $prefix . 'group',
-            'radioComponent' => $prefix . 'radio',
-        ]);
+        return view('splade::form.radios');
     }
 }

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -23,19 +23,12 @@ class Modal extends Component
      */
     public function render()
     {
-        $prefix = config('splade.blade.component_prefix');
-
-        if ($prefix) {
-            $prefix .= '-';
-        }
-
         return $this->splade->isModalRequest()
             ? view(
                 $this->splade->modalType() === SpladeCore::MODAL_TYPE_MODAL ? 'splade::modal' : 'splade::slideover',
                 [
                     'closeButton' => $this->closeButton,
                     'modalKey'    => $this->splade->getModalKey(),
-                    'wrapperName' => $prefix . 'modal-wrapper',
                 ]
             )
             : '{{ $slot }}';

--- a/src/Components/SpladeComponent.php
+++ b/src/Components/SpladeComponent.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace ProtoneMedia\Splade\Components;
+
+use Illuminate\View\DynamicComponent;
+
+class SpladeComponent extends DynamicComponent
+{
+    /**
+     * Create a new component instance.
+     *
+     * @param  string  $component
+     * @return void
+     */
+    public function __construct(string $is)
+    {
+        $prefix = config('splade.blade.component_prefix');
+
+        if ($prefix) {
+            $prefix .= '-';
+        }
+
+        $this->component = $prefix . $is;
+    }
+}

--- a/src/Components/Table.php
+++ b/src/Components/Table.php
@@ -65,15 +65,8 @@ class Table extends Component
      */
     public function render()
     {
-        $prefix = config('splade.blade.component_prefix');
-
-        if ($prefix) {
-            $prefix .= '-';
-        }
-
         return view('splade::table.table', [
             'table'          => $this->for,
-            'wrapperName'    => $prefix . 'table-wrapper',
             'paginationView' => $this->isLengthAware() ? 'splade::table.pagination' : 'splade::table.simple-pagination',
         ]);
     }

--- a/src/Components/Transition.php
+++ b/src/Components/Transition.php
@@ -18,7 +18,6 @@ class Transition extends Component
         private bool $appear = false,
         private bool $unmount = true,
         private bool $child = false,
-        public string $as = 'div',
         private string $afterLeave = '',
         public string $scope = 'transition',
     ) {

--- a/src/Components/Transition.php
+++ b/src/Components/Transition.php
@@ -3,6 +3,7 @@
 namespace ProtoneMedia\Splade\Components;
 
 use Illuminate\View\Component;
+use ProtoneMedia\Splade\TransitionRepository;
 
 class Transition extends Component
 {
@@ -11,7 +12,7 @@ class Transition extends Component
      *
      * @return void
      */
-    public function __construct(public string $scope = 'transition')
+    public function __construct(public string $show, private string $animation = 'default', public string $scope = 'transition')
     {
     }
 
@@ -22,6 +23,10 @@ class Transition extends Component
      */
     public function render()
     {
-        return view('splade::transition');
+        $transitionRepository = app(TransitionRepository::class);
+
+        return view('splade::transition', [
+            'animation' => $transitionRepository->get('default'),
+        ]);
     }
 }

--- a/src/Components/Transition.php
+++ b/src/Components/Transition.php
@@ -12,8 +12,15 @@ class Transition extends Component
      *
      * @return void
      */
-    public function __construct(public string $show, private string $animation = 'default', public string $scope = 'transition')
-    {
+    public function __construct(
+        private string $show = '',
+        private string $animation = 'default',
+        private bool $appear = false,
+        private bool $child = false,
+        public string $as = 'div',
+        private string $afterLeave = '',
+        public string $scope = 'transition',
+    ) {
     }
 
     /**
@@ -26,7 +33,11 @@ class Transition extends Component
         $transitionRepository = app(TransitionRepository::class);
 
         return view('splade::transition', [
-            'animation' => $transitionRepository->get('default'),
+            'animation'  => $transitionRepository->get($this->animation),
+            'child'      => $this->child,
+            'show'       => $this->show,
+            'appear'     => $this->appear,
+            'afterLeave' => $this->afterLeave,
         ]);
     }
 }

--- a/src/Components/Transition.php
+++ b/src/Components/Transition.php
@@ -16,6 +16,7 @@ class Transition extends Component
         private string $show = '',
         private string $animation = 'default',
         private bool $appear = false,
+        private bool $unmount = true,
         private bool $child = false,
         public string $as = 'div',
         private string $afterLeave = '',
@@ -37,6 +38,7 @@ class Transition extends Component
             'child'      => $this->child,
             'show'       => $this->show,
             'appear'     => $this->appear,
+            'unmount'    => $this->unmount,
             'afterLeave' => $this->afterLeave,
         ]);
     }

--- a/src/Facades/Animation.php
+++ b/src/Facades/Animation.php
@@ -11,7 +11,7 @@ use ProtoneMedia\Splade\TransitionAnimation;
  *
  * @see \ProtoneMedia\Splade\TransitionRepository
  */
-class Transition extends Facade
+class Animation extends Facade
 {
     protected static function getFacadeAccessor()
     {

--- a/src/Facades/Transition.php
+++ b/src/Facades/Transition.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ProtoneMedia\Splade\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use ProtoneMedia\Splade\TransitionAnimation;
+
+/**
+ * @method static self add(TransitionAnimation $transitionAnimation)
+ * @method static self new(string $name, string $enter, string $enterFrom, string $enterTo, string $leave, string $leaveFrom, string $leaveTo)
+ *
+ * @see \ProtoneMedia\Splade\TransitionRepository
+ */
+class Transition extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'laravel-splade-transition-repository';
+    }
+}

--- a/src/Http/SpladeMiddleware.php
+++ b/src/Http/SpladeMiddleware.php
@@ -142,12 +142,6 @@ class SpladeMiddleware
 
     public static function renderedComponents(): string
     {
-        $bladePrefix = config('splade.blade.component_prefix');
-
-        if ($bladePrefix) {
-            $bladePrefix .= '-';
-        }
-
-        return Blade::render("<x-{$bladePrefix}confirm /><x-{$bladePrefix}toast-wrapper />");
+        return Blade::render('<x-splade-component is="confirm" /><x-splade-component is="toast-wrapper" />');
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,7 +13,7 @@ use Laravel\Dusk\Browser;
 use ProtoneMedia\Splade\Commands\PublishFormStylesheetsCommand;
 use ProtoneMedia\Splade\Commands\SpladeInstallCommand;
 use ProtoneMedia\Splade\Commands\SsrTestCommand;
-use ProtoneMedia\Splade\Facades\Transition;
+use ProtoneMedia\Splade\Facades\Animation;
 use ProtoneMedia\Splade\Http\BladeDirectives;
 
 class ServiceProvider extends BaseServiceProvider
@@ -62,7 +62,7 @@ class ServiceProvider extends BaseServiceProvider
         });
 
         $this->app->alias(Head::class, 'laravel-splade-seo');
-        $this->app->alias(Transition::class, 'laravel-splade-transition-repository');
+        $this->app->alias(Animation::class, 'laravel-splade-transition-repository');
 
         (new BladeDirectives)->registerHandlers();
         $this->registerBladeComponents();
@@ -118,6 +118,7 @@ class ServiceProvider extends BaseServiceProvider
             Components\Confirm::class,
             Components\Data::class,
             Components\Defer::class,
+            Components\Dialog::class,
             Components\Dropdown::class,
             Components\Errors::class,
             Components\Event::class,
@@ -202,39 +203,39 @@ class ServiceProvider extends BaseServiceProvider
         $transitionRepository
             ->new(
                 name: 'default',
-                enter: 'ease-in-out duration-300',
+                enter: 'transition transform ease-in-out duration-300',
                 enterFrom: 'opacity-0 scale-95',
                 enterTo: 'opacity-100 scale-100',
-                leave: 'ease-in-out duration-300',
+                leave: 'transition transform ease-in-out duration-300',
                 leaveFrom: 'opacity-100 scale-100',
                 leaveTo: 'opacity-0 scale-95',
             )
             ->new(
                 name: 'opacity',
-                enter: 'ease-in-out duration-300',
+                enter: 'transition ease-in-out duration-300',
                 enterFrom: 'opacity-0',
                 enterTo: 'opacity-100',
-                leave: 'ease-in-out duration-300',
+                leave: 'transition ease-in-out duration-300',
                 leaveFrom: 'opacity-100',
                 leaveTo: 'opacity-0',
             )
             ->new(
                 name: 'fade',
-                enter: 'ease-in-out duration-300',
+                enter: 'transition transform ease-in-out duration-300',
                 enterFrom: 'opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95',
                 enterTo: 'opacity-100 translate-y-0 sm:scale-100',
-                leave: 'ease-in-out duration-200',
+                leave: 'transition transform ease-in-out duration-300',
                 leaveFrom: 'opacity-100 translate-y-0 sm:scale-100',
                 leaveTo: 'opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95',
             )
             ->new(
                 name: 'slideRight',
-                enter: 'transform ease-in-out duration-300',
-                enterFrom: 'translate-x-full',
-                enterTo: 'translate-x-0',
-                leave: 'transform ease-in-out duration-300',
-                leaveFrom: 'translate-x-0',
-                leaveTo: 'translate-x-full',
+                enter: 'transform transform ease-in-out duration-300',
+                enterFrom: 'opacity-0 translate-x-full',
+                enterTo: 'opacity-100 translate-x-0',
+                leave: 'transform transform ease-in-out duration-300',
+                leaveFrom: 'opacity-100 translate-x-0',
+                leaveTo: 'opacity-0 translate-x-full',
             );
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -198,28 +198,10 @@ class ServiceProvider extends BaseServiceProvider
         $transitionRepository
             ->add(new TransitionAnimation(
                 name: 'default',
-                enter: 'transition ease-out duration-300',
+                enter: 'ease-in-out duration-300',
                 enterFrom: 'opacity-0 scale-95',
                 enterTo: 'opacity-100 scale-100',
-                leave: 'transition ease-in duration-300',
-                leaveFrom: 'opacity-100 scale-100',
-                leaveTo: 'opacity-0 scale-95',
-            ))
-            ->add(new TransitionAnimation(
-                name: 'defaultInOut',
-                enter: 'transform transition ease-in-out duration-300',
-                enterFrom: 'opacity-0 scale-95',
-                enterTo: 'opacity-100 scale-100',
-                leave: 'transform transition ease-in-out duration-300',
-                leaveFrom: 'opacity-100 scale-100',
-                leaveTo: 'opacity-0 scale-95',
-            ))
-            ->add(new TransitionAnimation(
-                name: 'opacityScale',
-                enter: 'transition ease-out duration-300',
-                enterFrom: 'opacity-0 scale-95',
-                enterTo: 'opacity-100 scale-100',
-                leave: 'transition ease-in duration-300',
+                leave: 'ease-in-out duration-300',
                 leaveFrom: 'opacity-100 scale-100',
                 leaveTo: 'opacity-0 scale-95',
             ))
@@ -243,10 +225,10 @@ class ServiceProvider extends BaseServiceProvider
             ))
             ->add(new TransitionAnimation(
                 name: 'slideRight',
-                enter: 'transition transform ease-in-out duration-300',
+                enter: 'transform ease-in-out duration-300',
                 enterFrom: 'translate-x-full',
                 enterTo: 'translate-x-0',
-                leave: 'transition transform ease-in-out duration-300',
+                leave: 'transform ease-in-out duration-300',
                 leaveFrom: 'translate-x-0',
                 leaveTo: 'translate-x-full',
             ));

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -55,11 +55,19 @@ class ServiceProvider extends BaseServiceProvider
             return $app->make(SpladeCore::class)->head();
         });
 
+        $this->app->singleton(TransitionRepository::class, function ($app) {
+            return new TransitionRepository;
+        });
+
         $this->app->alias(Head::class, 'laravel-splade-seo');
 
         (new BladeDirectives)->registerHandlers();
         $this->registerBladeComponents();
         $this->registerDuskMacros();
+
+        $this->registerTransitionAnimations(
+            $this->app->make(TransitionRepository::class)
+        );
 
         Route::get(config('splade.event_redirect_route'), function ($uuid) {
             $data = Cache::pull(EventRedirect::class . $uuid);
@@ -156,6 +164,29 @@ class ServiceProvider extends BaseServiceProvider
                     });
             });
         }
+    }
+
+    public static function registerTransitionAnimations(TransitionRepository $transitionRepository)
+    {
+        $transitionRepository
+            ->add(new TransitionAnimation(
+                name: 'default',
+                enter: 'transition ease-out duration-200',
+                enterFrom: 'opacity-0 scale-95',
+                enterTo: 'opacity-100 scale-100',
+                leave: 'transition ease-in duration-200',
+                leaveFrom: 'opacity-100 scale-100',
+                leaveTo: 'opacity-0 scale-95',
+            ))
+            ->add(new TransitionAnimation(
+                name: 'fromRight',
+                enter: 'transition transform ease-in-out duration-300',
+                enterFrom: 'translate-x-full',
+                enterTo: 'translate-x-0',
+                leave: 'transition transform ease-in-out duration-300',
+                leaveFrom: 'translate-x-0',
+                leaveTo: 'translate-x-full',
+            ));
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -242,7 +242,7 @@ class ServiceProvider extends BaseServiceProvider
                 leaveTo: 'opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95',
             ))
             ->add(new TransitionAnimation(
-                name: 'fromRight',
+                name: 'slideRight',
                 enter: 'transition transform ease-in-out duration-300',
                 enterFrom: 'translate-x-full',
                 enterTo: 'translate-x-0',

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,7 +13,6 @@ use Laravel\Dusk\Browser;
 use ProtoneMedia\Splade\Commands\PublishFormStylesheetsCommand;
 use ProtoneMedia\Splade\Commands\SpladeInstallCommand;
 use ProtoneMedia\Splade\Commands\SsrTestCommand;
-use ProtoneMedia\Splade\Facades\Animation;
 use ProtoneMedia\Splade\Http\BladeDirectives;
 
 class ServiceProvider extends BaseServiceProvider
@@ -62,7 +61,7 @@ class ServiceProvider extends BaseServiceProvider
         });
 
         $this->app->alias(Head::class, 'laravel-splade-seo');
-        $this->app->alias(Animation::class, 'laravel-splade-transition-repository');
+        $this->app->alias(TransitionRepository::class, 'laravel-splade-transition-repository');
 
         (new BladeDirectives)->registerHandlers();
         $this->registerBladeComponents();

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -13,6 +13,7 @@ use Laravel\Dusk\Browser;
 use ProtoneMedia\Splade\Commands\PublishFormStylesheetsCommand;
 use ProtoneMedia\Splade\Commands\SpladeInstallCommand;
 use ProtoneMedia\Splade\Commands\SsrTestCommand;
+use ProtoneMedia\Splade\Facades\Transition;
 use ProtoneMedia\Splade\Http\BladeDirectives;
 
 class ServiceProvider extends BaseServiceProvider
@@ -61,12 +62,13 @@ class ServiceProvider extends BaseServiceProvider
         });
 
         $this->app->alias(Head::class, 'laravel-splade-seo');
+        $this->app->alias(Transition::class, 'laravel-splade-transition-repository');
 
         (new BladeDirectives)->registerHandlers();
         $this->registerBladeComponents();
         $this->registerDuskMacros();
 
-        $this->registerTransitionAnimations(
+        static::registerTransitionAnimations(
             $this->app->make(TransitionRepository::class)
         );
 
@@ -109,6 +111,8 @@ class ServiceProvider extends BaseServiceProvider
 
     private function registerBladeComponents()
     {
+        Blade::component(Components\SpladeComponent::class);
+
         Blade::components([
             Components\ButtonWithDropdown::class,
             Components\Confirm::class,
@@ -196,7 +200,7 @@ class ServiceProvider extends BaseServiceProvider
     public static function registerTransitionAnimations(TransitionRepository $transitionRepository)
     {
         $transitionRepository
-            ->add(new TransitionAnimation(
+            ->new(
                 name: 'default',
                 enter: 'ease-in-out duration-300',
                 enterFrom: 'opacity-0 scale-95',
@@ -204,8 +208,8 @@ class ServiceProvider extends BaseServiceProvider
                 leave: 'ease-in-out duration-300',
                 leaveFrom: 'opacity-100 scale-100',
                 leaveTo: 'opacity-0 scale-95',
-            ))
-            ->add(new TransitionAnimation(
+            )
+            ->new(
                 name: 'opacity',
                 enter: 'ease-in-out duration-300',
                 enterFrom: 'opacity-0',
@@ -213,17 +217,17 @@ class ServiceProvider extends BaseServiceProvider
                 leave: 'ease-in-out duration-300',
                 leaveFrom: 'opacity-100',
                 leaveTo: 'opacity-0',
-            ))
-            ->add(new TransitionAnimation(
+            )
+            ->new(
                 name: 'fade',
-                enter: 'ease-out duration-300',
+                enter: 'ease-in-out duration-300',
                 enterFrom: 'opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95',
                 enterTo: 'opacity-100 translate-y-0 sm:scale-100',
-                leave: 'ease-in duration-200',
+                leave: 'ease-in-out duration-200',
                 leaveFrom: 'opacity-100 translate-y-0 sm:scale-100',
                 leaveTo: 'opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95',
-            ))
-            ->add(new TransitionAnimation(
+            )
+            ->new(
                 name: 'slideRight',
                 enter: 'transform ease-in-out duration-300',
                 enterFrom: 'translate-x-full',
@@ -231,7 +235,7 @@ class ServiceProvider extends BaseServiceProvider
                 leave: 'transform ease-in-out duration-300',
                 leaveFrom: 'translate-x-0',
                 leaveTo: 'translate-x-full',
-            ));
+            );
     }
 
     /**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -229,7 +229,7 @@ class ServiceProvider extends BaseServiceProvider
                 leaveTo: 'opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95',
             )
             ->new(
-                name: 'slideRight',
+                name: 'slide-right',
                 enter: 'transform transform ease-in-out duration-300',
                 enterFrom: 'opacity-0 translate-x-full',
                 enterTo: 'opacity-100 translate-x-0',

--- a/src/SpladeCore.php
+++ b/src/SpladeCore.php
@@ -131,17 +131,6 @@ class SpladeCore
         return $this;
     }
 
-    public function component(string $name): string
-    {
-        $prefix = config('splade.blade.component_prefix');
-
-        if ($prefix) {
-            $prefix .= '-';
-        }
-
-        return $prefix . $name;
-    }
-
     public function isSpladeRequest(): bool
     {
         return $this->request()->hasHeader(static::HEADER_SPLADE);

--- a/src/SpladeCore.php
+++ b/src/SpladeCore.php
@@ -131,6 +131,17 @@ class SpladeCore
         return $this;
     }
 
+    public function component(string $name): string
+    {
+        $prefix = config('splade.blade.component_prefix');
+
+        if ($prefix) {
+            $prefix .= '-';
+        }
+
+        return $prefix . $name;
+    }
+
     public function isSpladeRequest(): bool
     {
         return $this->request()->hasHeader(static::HEADER_SPLADE);

--- a/src/TransitionAnimation.php
+++ b/src/TransitionAnimation.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace ProtoneMedia\Splade;
+
+class TransitionAnimation
+{
+    public function __construct(
+        private string $name,
+        private string $enter,
+        private string $enterFrom,
+        private string $enterTo,
+        private string $leave,
+        private string $leaveFrom,
+        private string $leaveTo
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function toArray()
+    {
+        return [
+            'enter'      => $this->enter,
+            'enter-from' => $this->enterFrom,
+            'enter-to'   => $this->enterTo,
+            'leave'      => $this->leave,
+            'leave-from' => $this->leaveFrom,
+            'leave-to'   => $this->leaveTo,
+        ];
+    }
+}

--- a/src/TransitionRepository.php
+++ b/src/TransitionRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ProtoneMedia\Splade;
+
+class TransitionRepository
+{
+    private $animations = [];
+
+    public function __construct()
+    {
+    }
+
+    public function add(TransitionAnimation $transitionAnimation): self
+    {
+        $this->animations[$transitionAnimation->getName()] = $transitionAnimation;
+
+        return $this;
+    }
+
+    public function get($name): TransitionAnimation
+    {
+        return $this->animations[$name];
+    }
+
+    public function classes(): array
+    {
+        return collect($this->animations)->flatMap(function (TransitionAnimation $transitionAnimation) {
+            $classes = implode(' ', $transitionAnimation->toArray());
+
+            return explode(' ', $classes);
+        })->unique()->sort()->values()->all();
+    }
+}

--- a/src/TransitionRepository.php
+++ b/src/TransitionRepository.php
@@ -17,6 +17,20 @@ class TransitionRepository
         return $this;
     }
 
+    public function new(
+        string $name,
+        string $enter,
+        string $enterFrom,
+        string $enterTo,
+        string $leave,
+        string $leaveFrom,
+        string $leaveTo
+    ): self {
+        return $this->add(
+            new TransitionAnimation($name, $enter, $enterFrom, $enterTo, $leave, $leaveFrom, $leaveTo)
+        );
+    }
+
     public function get($name): TransitionAnimation
     {
         return $this->animations[$name];


### PR DESCRIPTION
* New `Transition` component with support for presets
* New internal `Dialog` component
* Refactored all internal transitions/dialogs to the new components
* New internal `<x-splade-component>` that dynamically loads Splade Components with support for custom prefixes