### PR TITLE
Add automatic npm install and run build command

### DIFF
--- a/src/Commands/SpladeInstallCommand.php
+++ b/src/Commands/SpladeInstallCommand.php
@@ -82,9 +82,10 @@ class SpladeInstallCommand extends Command
             $this->runCommands(['yarn install', 'yarn run build']);
         } else {
             $this->runCommands(['npm install', 'npm run build']);
-        }
-        
+        }        
+               
         $this->comment('All done');
+        $this->comment('Execute "npm run dev" to start the Vite dev server.');
         
 
         return self::SUCCESS;

--- a/src/Commands/SpladeInstallCommand.php
+++ b/src/Commands/SpladeInstallCommand.php
@@ -75,8 +75,17 @@ class SpladeInstallCommand extends Command
         copy(__DIR__ . '/../../stubs/resources/js/app.js', resource_path('js/app.js'));
         copy(__DIR__ . '/../../stubs/resources/js/ssr.js', resource_path('js/ssr.js'));
 
+        // Run npm install & npm run build automatically
+        if (file_exists(base_path('pnpm-lock.yaml'))) {
+            $this->runCommands(['pnpm install', 'pnpm run build']);
+        } elseif (file_exists(base_path('yarn.lock'))) {
+            $this->runCommands(['yarn install', 'yarn run build']);
+        } else {
+            $this->runCommands(['npm install', 'npm run build']);
+        }
+        
         $this->comment('All done');
-        $this->comment('Please execute "npm install && npm run dev" to build your assets.');
+        
 
         return self::SUCCESS;
     }

--- a/src/Commands/SpladeInstallCommand.php
+++ b/src/Commands/SpladeInstallCommand.php
@@ -4,6 +4,8 @@ namespace ProtoneMedia\Splade\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
 
 class SpladeInstallCommand extends Command
 {
@@ -82,11 +84,10 @@ class SpladeInstallCommand extends Command
             $this->runCommands(['yarn install', 'yarn run build']);
         } else {
             $this->runCommands(['npm install', 'npm run build']);
-        }        
-               
+        }
+
         $this->comment('All done');
         $this->comment('Execute "npm run dev" to start the Vite dev server.');
-        
 
         return self::SUCCESS;
     }
@@ -148,5 +149,28 @@ class SpladeInstallCommand extends Command
             base_path('package.json'),
             json_encode($packages, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT) . static::eol()
         );
+    }
+
+    /**
+     * Run the given commands.
+     *
+     * @param  array  $commands
+     * @return void
+     */
+    protected function runCommands($commands)
+    {
+        $process = Process::fromShellCommandline(implode(' && ', $commands), null, null, null, null);
+
+        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+            try {
+                $process->setTty(true);
+            } catch (RuntimeException $e) {
+                $this->output->writeln('  <bg=yellow;fg=black> WARN </> ' . $e->getMessage() . PHP_EOL);
+            }
+        }
+
+        $process->run(function ($type, $line) {
+            $this->output->write('    ' . $line);
+        });
     }
 }


### PR DESCRIPTION
This fix provides automatic `npm install & npm run build` command run for the installation process.
So users no longer need to run these commands manually.