### PR TITLE
refactor: localization wrappers __() for the Reset and Remove search …

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -11,6 +11,8 @@
     "Item selected": "",
     "Items selected": "",
     "Pagination Navigation": "",
+    "Remove search": "",
+    "Reset": "",
     "Search": "",
     "Select all on this page": "",
     "Select all results": "",

--- a/resources/views/table/controls.blade.php
+++ b/resources/views/table/controls.blade.php
@@ -28,7 +28,7 @@
             <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
         </svg>
 
-        <span class="ml-2 hidden sm:inline">Reset</span>
+        <span class="ml-2 hidden sm:inline">{{ __('Reset') }}</span>
     </button>
 
     @if($table->hasToggleableSearchInputs())

--- a/resources/views/table/search-row.blade.php
+++ b/resources/views/table/search-row.blade.php
@@ -30,7 +30,7 @@
                 @click.prevent="table.disableSearchInput(@js($searchInput->key))"
                 dusk="remove-search-row-{{ $searchInput->key }}"
             >
-                <span class="sr-only">Remove search</span>
+                <span class="sr-only">{{ __('Remove search') }}</span>
 
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
Two edits to make the Localization fuller

`<span class="sr-only">{{ __('Remove search') }}</span>`
and
`<span class="ml-2 hidden sm:inline">{{ __('Reset') }}</span>`