### PR TITLE
Form + Middleware refactor

### DIFF
--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -83,9 +83,7 @@ Route::middleware('splade')->group(function () {
     Route::view('event', 'event')->name('event');
 
     Route::get('flash/put', function () {
-        session()->flash('message', 'This is a message');
-
-        return redirect()->route('flash');
+        return redirect()->route('flash')->with('message', 'This is a message');
     });
 
     Route::view('flash', 'flash')->name('flash');

--- a/app/tests/Browser/StateTest.php
+++ b/app/tests/Browser/StateTest.php
@@ -14,6 +14,7 @@ class StateTest extends DuskTestCase
             $browser->visit('/state')
                 ->waitForText('StateComponent')
                 ->assertSee('This is shared')
+                ->assertDontSee('This is a message')
                 ->press('Submit')
                 ->waitUntilMissing('This is shared')
                 ->assertSee('Whoops!')

--- a/app/tests/Browser/Table/PreserveScrollTest.php
+++ b/app/tests/Browser/Table/PreserveScrollTest.php
@@ -64,7 +64,7 @@ class PreserveScrollTest extends DuskTestCase
                 ->press('tr:nth-child(30) td:nth-child(2) a')
                 ->waitForText('Project updated!');
 
-            $this->assertEquals("{$company} 2", $latestProject->fresh()->name);
+            $this->assertEquals("updated-{$company}", $latestProject->fresh()->name);
             $this->assertEquals($scrollY, $browser->script('return window.scrollY'));
         });
     }

--- a/lib/Components/Form.vue
+++ b/lib/Components/Form.vue
@@ -144,9 +144,7 @@ export default {
             type: Object,
             required: false,
             default: () => {
-                return {
-                    // "Accept": "application/json",
-                };
+                return {};
             },
         },
     },

--- a/lib/Components/Form.vue
+++ b/lib/Components/Form.vue
@@ -139,6 +139,16 @@ export default {
             required: false,
             default: 0
         },
+
+        headers: {
+            type: Object,
+            required: false,
+            default: () => {
+                return {
+                    // "Accept": "application/json",
+                };
+            },
+        },
     },
 
     emits: ["success", "error", "reset", "restored"],
@@ -440,13 +450,16 @@ export default {
             this.wasSuccessful = false;
             this.recentlySuccessful = false;
             clearTimeout(this.recentlySuccessfulTimeoutId);
+
+            this.wasUnsuccessful = false;
+            this.recentlyUnsuccessful = false;
             clearTimeout(this.recentlyUnsuccessfulTimeoutId);
 
             const data = (this.values instanceof FormData)
                 ? this.values
                 : objectToFormData(this.values);
 
-            const headers = { Accept: "application/json" };
+            const headers = { ...this.headers };
 
             if(this.stay || forceStay) {
                 headers["X-Splade-Prevent-Refresh"] = true;
@@ -477,9 +490,6 @@ export default {
                 this.processing = false;
                 this.processingInBackground = false;
 
-                this.wasUnsuccessful = false;
-                this.recentlyUnsuccessful = false;
-
                 this.wasSuccessful = true;
                 this.recentlySuccessful = true;
                 this.recentlySuccessfulTimeoutId = setTimeout(() => this.recentlySuccessful = false, 2000);
@@ -494,9 +504,6 @@ export default {
                 .catch(async (error) => {
                     this.processing = false;
                     this.processingInBackground = false;
-
-                    this.wasSuccessful = false;
-                    this.recentlySuccessful = false;
 
                     this.wasUnsuccessful = true;
                     this.recentlyUnsuccessful = true;

--- a/src/Http/SpladeMiddleware.php
+++ b/src/Http/SpladeMiddleware.php
@@ -51,6 +51,9 @@ class SpladeMiddleware
         $this->splade->resetRehydrateComponentCounter();
         $this->splade->resetPersistentLayoutKey();
 
+        $session = $request->session();
+        $session->forget('errors');
+
         /** @var Response $response */
         $response = $next($request);
         $response->headers->add(['Vary' => 'X-Splade']);
@@ -68,7 +71,7 @@ class SpladeMiddleware
         }
 
         // Gather the required meta data for the app.
-        $spladeData = $this->spladeData($request->session());
+        $spladeData = $this->spladeData($session);
 
         // The response should redirect away from the Splade app.
         if ($redirect = $this->shouldRedirectsAway($response)) {
@@ -78,7 +81,7 @@ class SpladeMiddleware
         // If the response is a redirect, put the toasts into the session
         // so they won't be lost in the next request.
         if (in_array($response->getStatusCode(), [302, 303])) {
-            $request->session()->put(static::FLASH_TOASTS, $this->splade->getToasts());
+            $session->put(static::FLASH_TOASTS, $this->splade->getToasts());
         }
 
         // A Splade request is a request made by the Vue app, so not the initial first request.
@@ -108,6 +111,18 @@ class SpladeMiddleware
      */
     private function handleSpladeRequest(Request $request, Response $response, object $spladeData): Response
     {
+        // If the response is not a JsonResponse, but the session contains errors,
+        // we need to convert it to one so Splade can handle the errors.
+        if (!$response instanceof JsonResponse && $spladeData->hasErrors) {
+            $exception = ValidationException::withMessages($request->session()->get('errors')->toArray());
+
+            /** @see \Illuminate\Foundation\Exceptions\Handler@invalidJson */
+            $response = response()->json([
+                'message' => $exception->getMessage(),
+                'errors'  => $exception->errors(),
+            ], $exception->status);
+        }
+
         // We don't mess with JsonResponses, except we add the Splade data to it.
         if ($response instanceof JsonResponse) {
             $decodedData = $response->getData(true);
@@ -123,10 +138,14 @@ class SpladeMiddleware
 
             // Get the Validation Errors from the exception and put them in the Splade data.
             if ($response->exception instanceof ValidationException) {
-                $newData['splade']->errors = $response->exception->errors();
+                $newData['splade']->errors = (object) $response->exception->errors();
             }
 
             return $response->setData($newData);
+        }
+
+        if ($response->isRedirect() && $this->splade->dontRefreshPage()) {
+            $response = response()->noContent(200);
         }
 
         if (!$response->isSuccessful()) {
@@ -302,12 +321,15 @@ class SpladeMiddleware
 
         $excludeHead = $this->splade->isLazyRequest() || $this->splade->isRehydrateRequest();
 
+        $errors = $session->get('errors')?->toArray();
+
         return (object) [
             'head'        => $excludeHead ? [] : $this->splade->head()->toArray(),
             'modal'       => $this->splade->isModalRequest() ? $this->splade->getModalType() : null,
             'modalTarget' => $this->splade->getModalTarget() ?: null,
             'flash'       => (object) $flash,
-            'errors'      => (object) session('errors')?->toArray(),
+            'errors'      => (object) $errors,
+            'hasErrors'   => !empty($errors),
             'shared'      => (object) $this->splade->getShared(),
             'toasts'      => array_merge(
                 $session->pull(static::FLASH_TOASTS, []),

--- a/src/Http/SpladeMiddleware.php
+++ b/src/Http/SpladeMiddleware.php
@@ -120,7 +120,7 @@ class SpladeMiddleware
             $response = response()->json([
                 'message' => $exception->getMessage(),
                 'errors'  => $exception->errors(),
-            ], $exception->status);
+            ], $exception->status)->withException($exception);
         }
 
         // We don't mess with JsonResponses, except we add the Splade data to it.

--- a/src/Http/SpladeMiddleware.php
+++ b/src/Http/SpladeMiddleware.php
@@ -107,9 +107,9 @@ class SpladeMiddleware
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Http\Response  $response
      * @param  object  $spladeData
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
-    private function handleSpladeRequest(Request $request, Response $response, object $spladeData): Response
+    private function handleSpladeRequest(Request $request, Response $response, object $spladeData): Response|JsonResponse
     {
         // If the response is not a JsonResponse, but the session contains errors,
         // we need to convert it to one so Splade can handle the errors.


### PR DESCRIPTION
The Form component was the only component to send Splade requests using an `Accept: application/json` header. This PR refactors the header away while still receiving a 422 response on validation errors.