### PR TITLE
Add ability to use Closure as a sortable parameter in table's column

### DIFF
--- a/app/tests/Unit/SpladeQueryBuilderTest.php
+++ b/app/tests/Unit/SpladeQueryBuilderTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Unit;
 
+use App\Models\Address;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
 use ProtoneMedia\Splade\SpladeQueryBuilder;
+use ProtoneMedia\Splade\SpladeTable;
 use Tests\TestCase;
 
 class SpladeQueryBuilderTest extends TestCase
@@ -20,5 +23,24 @@ class SpladeQueryBuilderTest extends TestCase
         $this->assertEquals(['foo bar', 'baz'], $builder->parseTermsIntoCollection('"foo bar" baz')->all());
         $this->assertEquals(['0'], $builder->parseTermsIntoCollection('0')->all());
         $this->assertEquals(['1'], $builder->parseTermsIntoCollection('1')->all());
+    }
+
+    /** @test */
+    public function it_can_apply_sorting_with_a_closure()
+    {
+        $table = SpladeTable::for(Address::class)
+            ->column('two_columns', sortable: function ($builder, $direction) {
+                $builder->orderBy('address', $direction)
+                    ->orderBy('city', $direction);
+            })
+            ->defaultSort('two_columns');
+
+        DB::enableQueryLog();
+        $table->beforeRender();
+        DB::disableQueryLog();
+        $log = DB::getQueryLog();
+
+        $this->assertCount(1, $log);
+        $this->assertEquals('select * from "addresses" order by "address" asc, "city" asc', $log[0]['query']);
     }
 }

--- a/src/SpladeQueryBuilder.php
+++ b/src/SpladeQueryBuilder.php
@@ -194,6 +194,10 @@ class SpladeQueryBuilder extends SpladeTable
      */
     private function applySorting(Column $column)
     {
+        if (is_callable($column->sortable)) {
+            return ($column->sortable)($this->builder, $column->sorted);
+        }
+
         if (!$column->isNested()) {
             // Not a relationship, just a column on the table.
             return $this->builder->orderBy($column->key, $column->sorted);

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -60,7 +60,7 @@ class Column implements Arrayable
             'label'         => $this->label,
             'can_be_hidden' => $this->canBeHidden,
             'hidden'        => $this->hidden,
-            'sortable'      => $this->sortable,
+            'sortable'      => $this->sortable !== false,
             'sorted'        => $this->sorted,
             'highlight'     => $this->highlight,
         ];

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -20,7 +20,7 @@ class Column implements Arrayable
         public string $label,
         public bool $canBeHidden,
         public bool $hidden,
-        public bool $sortable,
+        public bool|Closure $sortable,
         public bool|string $sorted,
         public bool $highlight,
         public bool|Closure $exportAs,

--- a/src/Table/HasColumns.php
+++ b/src/Table/HasColumns.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Table;
 
+use Closure;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
@@ -48,7 +49,7 @@ trait HasColumns
         string $label = null,
         bool|null $canBeHidden = null,
         bool $hidden = false,
-        bool $sortable = false,
+        bool|Closure $sortable = false,
         bool|string $searchable = false,
         bool|null $highlight = null,
         bool|callable $exportAs = true,


### PR DESCRIPTION
Hi
This PR  makes possible to use self-defined Closure as `sortable` parameter for table's column. 

There can be a case when you need to sort by computed or virtual column.  You can't just set `sortable: true` in call to `column()` method. You can use Spatie Query Builder for such case. But this solution for those who don't want to install it just for one field.

So, let's say you have such Eloquent model:

```php
<?php

class Subscriber extends Model
{
    protected $appends = [
        'full_name',
    ];

    protected $fillable = [
        'first_name',
        'last_name',
    ];

    public function fullName(): Attribute
    {
        return Attribute::make(
            get: fn () => trim(sprintf('%s %s', $this->first_name, $this->last_name)),
        );
    }
}
```

And you want to sort by `full_name`. Then you can do:
```php
<?php

class SubscribersViewTable extends AbstractTable
{
    /**
     * Determine if the user is authorized to perform bulk actions and exports.
     *
     * @param Request $request
     * @return bool
     */
    public function authorize(Request $request): bool
    {
        return true;
    }

    /**
     * The resource or query builder.
     *
     */
    public function for(): Builder
    {
        return Subscriber::query();
    }

    /**
     * Configure the given SpladeTable.
     *
     * @param SpladeTable $table
     * @return void
     */
    public function configure(SpladeTable $table): void
    {
        $table
            ->withGlobalSearch(columns: [
                'first_name',
                'last_name',
            ])
            ->column(
                key: 'full_name',
                sortable: fn (Builder $query, string $direction) => $query
                    ->orderBy('first_name', $direction)
                    ->orderBy('last_name', $direction),
            )
            ->searchInput(
                key: ['first_name', 'last_name'],
                label: 'Full Name',
            )
            ->paginate(10)
        ;
    }
}
```

P.S. I don't find instructions on how to set-up tests. So, right now there are no tests of this functionality.