### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/run-stub-tests.yml
+++ b/.github/workflows/run-stub-tests.yml
@@ -21,6 +21,14 @@ jobs:
         exclude:
           - laravel: 10.*
             php: 8.0
+          - laravel: 9.*
+            os: windows-latest
+          - php: 8.1
+            os: windows-latest
+          - php: 8.0
+            os: windows-latest
+          - dependency-version: prefer-lowest
+            os: windows-latest
 
     name: Test Stubs ${{ matrix.os }} - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/app/app/Http/Controllers/ModalController.php
+++ b/app/app/Http/Controllers/ModalController.php
@@ -17,7 +17,9 @@ class ModalController
     {
         SEO::title('Modal One');
 
-        return view('modal.one');
+        return view('modal.one', [
+            'closeExplicitly' => (bool) request()->query('closeExplicitly'),
+        ]);
     }
 
     public function two()

--- a/app/resources/views/modal/base.blade.php
+++ b/app/resources/views/modal/base.blade.php
@@ -11,6 +11,7 @@ ModalComponent
     <Link modal dusk="validation" href="{{ route('modal.validation') }}">Open Modal Validation</Link>
     <Link modal dusk="libraries" href="{{ route('form.components.libraries') }}">Open Form Libraries</Link>
     <Link modal dusk="form-select" href="{{ route('form.components.customSelectOptions') }}">Open Custom Select Options</Link>
+    <Link modal dusk="one-close-explicitly" href="{{ route('modal.one', ['closeExplicitly' => 1]) }}">Open Modal One (Close Explicitly)</Link>
 </div>
 
 <div class="flex space-x-3">
@@ -42,7 +43,7 @@ ModalComponent
 <div class="flex space-x-3">
     <Link dusk="menu-modal" href="#menu-modal">Preloaded modal</Link>
     <Link dusk="menu-slideover" href="#menu-slideover">Preloaded slideover</Link>
-    <Link dusk="menu-modal-large" href="#menu-modal-large">Preloaded modal (large)</Link>
+    <Link dusk="menu-modal-large" href="#menu-modal-large">Preloaded modal (large, close explicitly)</Link>
     <Link dusk="menu-slideover-large" href="#menu-slideover-large">Preloaded slideover (large)</Link>
 </div>
 
@@ -54,7 +55,7 @@ ModalComponent
     <h1>Check out my slideover!</h1>
 </x-splade-modal>
 
-<x-splade-modal name="menu-modal-large" modal max-width="7xl">
+<x-splade-modal name="menu-modal-large" modal max-width="7xl" close-explicitly>
     <h1>Check out my modal!</h1>
 </x-splade-modal>
 

--- a/app/resources/views/modal/one.blade.php
+++ b/app/resources/views/modal/one.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
 
-<x-splade-modal>
+<x-splade-modal :close-explicitly="$closeExplicitly">
     ModalComponentOne
 
     <Link modal dusk="two" href="{{ route('modal.two') }}">Open Modal Two</Link>

--- a/app/tests/Browser/ModalTest.php
+++ b/app/tests/Browser/ModalTest.php
@@ -31,6 +31,24 @@ class ModalTest extends DuskTestCase
     }
 
     /** @test */
+    public function it_can_require_the_modal_to_be_explicitly_closed()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/modal/base')
+                ->resize(1024, 768)
+                ->waitForText('ModalComponent')
+                ->click('@one-close-explicitly')
+                ->waitForText('ModalComponentOne')
+                ->pause(500)
+                ->keys('', ['{escape}'])
+                ->pause(500)
+                ->assertSee('ModalComponentOne')
+                ->click('@close-one')
+                ->waitUntilMissingText('ModalComponentOne');
+        });
+    }
+
+    /** @test */
     public function it_can_do_nested_modals()
     {
         $this->browse(function (Browser $browser) {

--- a/app/tests/Browser/PreloadedModalTest.php
+++ b/app/tests/Browser/PreloadedModalTest.php
@@ -60,7 +60,7 @@ class PreloadedModalTest extends DuskTestCase
 
             $browser
                 ->pause(500)
-                ->click('@close-modal-button')
+                ->keys('', ['{escape}'])
                 ->pause(500)
                 ->waitUntilMissingText('Check out my slideover!');
         });
@@ -82,6 +82,25 @@ class PreloadedModalTest extends DuskTestCase
 
             $browser
                 ->pause(500)
+                ->click('@close-modal-button')
+                ->pause(500)
+                ->waitUntilMissingText('Check out my modal!');
+        });
+    }
+
+    /** @test */
+    public function it_can_disable_closing_the_model_implicitly()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit('/modal/base')
+                ->resize(1680, 900)
+                ->waitForText('ModalComponent')
+                ->click('@menu-modal-large')
+                ->waitForText('Check out my modal!')
+                ->pause(500)
+                ->keys('', ['{escape}'])
+                ->pause(500)
+                ->assertSee('Check out my modal!')
                 ->click('@close-modal-button')
                 ->pause(500)
                 ->waitUntilMissingText('Check out my modal!');

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -2,7 +2,7 @@
 
 <SpladeButton {{ $attributes->only(['v-bind:spinner', ':spinner']) }}>
     <template #default="button">
-        <button :disabled="button.spinner" {{ $attributes->class([
+        <{{ $type === 'link' ? 'Link' : 'button' }} :disabled="button.spinner" {{ $attributes->class([
             'border rounded-md shadow-sm font-bold py-2 px-4 focus:outline-none focus:ring focus:ring-opacity-50',
             'bg-indigo-500 hover:bg-indigo-700 text-white border-transparent focus:border-indigo-300 focus:ring-indigo-200' => !$customStyling && $primary,
             'bg-red-500 hover:bg-red-700 text-white border-transparent focus:border-red-700 focus:ring-red-200' => !$customStyling && $danger,
@@ -29,6 +29,6 @@
                     </span>
                 </div>
             @endif
-        </button>
+        </{{ $type === 'link' ? 'Link' : 'button' }}>
     </template>
 </SpladeButton>

--- a/resources/views/components/modal-wrapper.blade.php
+++ b/resources/views/components/modal-wrapper.blade.php
@@ -2,7 +2,7 @@
 <SpladeModal {{ $baseAttributes->mergeVueBinding(':close-button', $closeButton) }} :name="@js($name)">
     <template #default="modal">
         <x-splade-component is="transition" show="modal.isOpen">
-            <x-splade-component is="dialog" v-bind:dusk="`modal.${modal.stack}`" close="modal.setIsOpen" class="relative z-20">
+            <x-splade-component is="dialog" v-bind:dusk="`modal.${modal.stack}`" close="{{ $closeExplicitly ? '' : 'modal.setIsOpen' }}" class="relative z-20">
                 <!-- The backdrop, rendered as a fixed sibling to the panel container -->
                 <x-splade-component
                     is="transition" child

--- a/resources/views/components/modal.blade.php
+++ b/resources/views/components/modal.blade.php
@@ -1,4 +1,4 @@
-<x-splade-component is="modal-wrapper" :base-attributes="$attributes->except('class')" :key="$modalKey" :close-button="$closeButton" :name="$name">
+<x-splade-component is="modal-wrapper" :base-attributes="$attributes->except('class')" :key="$modalKey" :close-button="$closeButton" :close-explicitly="$closeExplicitly" :name="$name">
     <!-- Full-screen scrollable container -->
     <div class="fixed inset-0 z-40 overflow-y-auto p-4">
         <!-- Container to center the panel -->

--- a/resources/views/components/slideover.blade.php
+++ b/resources/views/components/slideover.blade.php
@@ -1,4 +1,4 @@
-<x-splade-component is="modal-wrapper" :base-attributes="$attributes->except('class')" :key="$modalKey" :close-button="$closeButton" :name="$name">
+<x-splade-component is="modal-wrapper" :base-attributes="$attributes->except('class')" :key="$modalKey" :close-button="$closeButton" :close-explicitly="$closeExplicitly" :name="$name">
     <!-- Full-screen scrollable container -->
     <div class="fixed inset-0 z-40 overflow-y-auto">
         <!-- Container to center the panel -->

--- a/resources/views/table/body.blade.php
+++ b/resources/views/table/body.blade.php
@@ -29,7 +29,7 @@
                         @click="(event) => table.visit(@js($table->rowLinks->get($itemKey)), @js($table->rowLinkType), event)"
                     @endif
                     v-show="table.columnIsVisible(@js($column->key))"
-                    class="whitespace-nowrap text-sm @if($loop->first && $hasBulkActions) pr-6 @else px-6 @endif py-4 @if($column->highlight) text-gray-900 font-medium @else text-gray-500 @endif @if($table->rowLinks->has($itemKey)) cursor-pointer @endif"
+                    class="whitespace-nowrap text-sm @if($loop->first && $hasBulkActions) pr-6 @else px-6 @endif py-4 @if($column->highlight) text-gray-900 font-medium @else text-gray-500 @endif @if($table->rowLinks->has($itemKey)) cursor-pointer @endif {{ $column->classes }}"
                 >
                     @isset(${'spladeTableCell' . $column->keyHash()})
                         {{ ${'spladeTableCell' . $column->keyHash()}($item, $itemKey) }}

--- a/resources/views/table/head.blade.php
+++ b/resources/views/table/head.blade.php
@@ -9,7 +9,7 @@
         @foreach($table->columns() as $column)
             <th
                 v-show="table.columnIsVisible(@js($column->key))"
-                class="@if($loop->first && $hasBulkActions) pr-6 @else px-6 @endif py-3 text-left text-xs font-medium tracking-wide text-gray-500"
+                class="@if($loop->first && $hasBulkActions) pr-6 @else px-6 @endif py-3 text-left text-xs font-medium tracking-wide text-gray-500 {{ $column->classes }}"
             >
                 @if($column->sortable)
                     <Link keep-modal dusk="sort-{{ $column->key }}" href="{{ $sortBy($column) }}">

--- a/src/Components/Form.php
+++ b/src/Components/Form.php
@@ -313,6 +313,16 @@ class Form extends Component
 
             $column = array_pop($parts);
 
+            $target = $this->model;
+
+            foreach ($parts as $relationName) {
+                if (!$target->isRelation($relationName)) {
+                    return;
+                }
+
+                $target = data_get($target, $relationName);
+            }
+
             $relation = data_get($this->model, implode('.', $parts));
 
             $relation = $transformer($relation);

--- a/src/Components/Modal.php
+++ b/src/Components/Modal.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
 use Illuminate\View\View;
+use ProtoneMedia\Splade\Facades\Splade;
 use ProtoneMedia\Splade\SpladeCore;
 
 class Modal extends Component
@@ -22,6 +23,7 @@ class Modal extends Component
         public bool $modal = false,
         public bool $slideover = false,
         public bool $opened = false,
+        public bool|null $closeExplicitly = null,
     ) {
         if (!$modal && !$slideover) {
             $this->modal = true;
@@ -29,6 +31,10 @@ class Modal extends Component
 
         if (!$name && $opened) {
             $this->name = Str::random();
+        }
+
+        if ($closeExplicitly === null) {
+            $this->closeExplicitly = Splade::getDefaultModalCloseExplicitly();
         }
     }
 
@@ -70,10 +76,11 @@ class Modal extends Component
         return view(
             $this->splade->getModalType() === SpladeCore::MODAL_TYPE_MODAL ? 'splade::components.modal' : 'splade::components.slideover',
             [
-                'closeButton' => $this->closeButton,
-                'modalKey'    => $this->splade->getModalKey(),
-                'wrapperName' => SpladeComponent::normalize('modal-wrapper'),
-                'name'        => $this->name,
+                'closeButton'     => $this->closeButton,
+                'closeExplicitly' => $this->closeExplicitly,
+                'modalKey'        => $this->splade->getModalKey(),
+                'wrapperName'     => SpladeComponent::normalize('modal-wrapper'),
+                'name'            => $this->name,
             ]
         );
     }

--- a/src/Components/ModalWrapper.php
+++ b/src/Components/ModalWrapper.php
@@ -16,6 +16,7 @@ class ModalWrapper extends Component
         public $baseAttributes,
         public bool $closeButton,
         public string $name = '',
+        public bool $closeExplicitly = false,
     ) {
     }
 

--- a/src/Facades/Splade.php
+++ b/src/Facades/Splade.php
@@ -43,6 +43,8 @@ use Symfony\Component\HttpFoundation\Response;
  * @method static self requireTransformer($value = true)
  * @method static self transformUsing($class, $transformer = null)
  * @method static mixed findTransformerFor(array|object $instance)
+ * @method static self defaultModalCloseExplicitly(bool $value = true)
+ * @method static bool getDefaultModalCloseExplicitly()
  *
  * @see \ProtoneMedia\Splade\SpladeCore
  */

--- a/src/SpladeCore.php
+++ b/src/SpladeCore.php
@@ -60,6 +60,8 @@ class SpladeCore
 
     private array $transformMap = [];
 
+    private bool $defaultModalCloseExplicitly = false;
+
     /**
      * Creates an instance.
      *
@@ -553,5 +555,23 @@ class SpladeCore
         }
 
         return null;
+    }
+
+    /**
+     * Setter for the 'defaultModalCloseExplicitly' property.
+     */
+    public function defaultModalCloseExplicitly(bool $value = true): self
+    {
+        $this->defaultModalCloseExplicitly = $value;
+
+        return $this;
+    }
+
+    /**
+     * Getter for the 'defaultModalCloseExplicitly' property.
+     */
+    public function getDefaultModalCloseExplicitly(): bool
+    {
+        return $this->defaultModalCloseExplicitly;
     }
 }

--- a/src/SpladeTable.php
+++ b/src/SpladeTable.php
@@ -4,6 +4,7 @@ namespace ProtoneMedia\Splade;
 
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
@@ -86,6 +87,10 @@ class SpladeTable
 
         if ($resource instanceof Model) {
             $resource = $resource->newQuery();
+        }
+
+        if ($resource instanceof Relation) {
+            $resource = $resource->getQuery();
         }
 
         if ($resource instanceof Builder || $resource instanceof SpatieQueryBuilder) {

--- a/src/Table/Column.php
+++ b/src/Table/Column.php
@@ -4,6 +4,7 @@ namespace ProtoneMedia\Splade\Table;
 
 use Closure;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
@@ -26,7 +27,13 @@ class Column implements Arrayable
         public bool|Closure $exportAs,
         public Closure|string|null $exportFormat = null,
         public Closure|array|null $exportStyling = null,
+        public array|string|null $classes = null,
     ) {
+        if (is_array($classes)) {
+            $classes = Arr::flatten($classes);
+        }
+
+        $this->classes = Arr::toCssClasses($classes);
     }
 
     /**
@@ -45,6 +52,7 @@ class Column implements Arrayable
             $this->exportAs,
             $this->exportFormat,
             $this->exportStyling,
+            $this->classes,
         );
     }
 

--- a/src/Table/HasColumns.php
+++ b/src/Table/HasColumns.php
@@ -53,7 +53,8 @@ trait HasColumns
         bool|null $highlight = null,
         bool|callable $exportAs = true,
         callable|string|null $exportFormat = null,
-        callable|array|null $exportStyling = null
+        callable|array|null $exportStyling = null,
+        array|string|null $classes = null,
     ): self {
         $key   = $key   !== null ? $key : Str::kebab($label);
         $label = $label !== null ? $label : Str::headline(str_replace('.', ' ', $key));
@@ -79,6 +80,7 @@ trait HasColumns
             exportAs: $exportAs,
             exportFormat: $exportFormat,
             exportStyling: $exportStyling,
+            classes: $classes,
         ))->values();
 
         if (!$searchable) {

--- a/src/Table/HasColumns.php
+++ b/src/Table/HasColumns.php
@@ -61,7 +61,7 @@ trait HasColumns
 
         $highlight = is_bool($highlight)
             ? $highlight
-            : static::$defaultHighlightFirstColumn;
+            : ($this->columns->isEmpty() ? static::$defaultHighlightFirstColumn : false);
 
         $canBeHidden = is_bool($canBeHidden)
             ? $canBeHidden


### PR DESCRIPTION
* Allow `x-splade-button` component to be a `Link` element (with `type="link")
* Support for closing modals explicitly (don't close on escape keypress or outside click)
* Support for Table column classes
* Transformer fix for nested data
* Allow Eloquent Relationship instances in Splade Table
* Only test Windows stubs on latest version