### PR TITLE
Update version search for new versions of npm

### DIFF
--- a/src/Commands/ShowSpladeVersions.php
+++ b/src/Commands/ShowSpladeVersions.php
@@ -3,6 +3,7 @@
 namespace ProtoneMedia\Splade\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 
 class ShowSpladeVersions extends Command
 {
@@ -37,7 +38,7 @@ class ShowSpladeVersions extends Command
         $npmPackage = collect($npmLockFile['packages'] ?? [])
             ->merge($npmLockFile['dependencies'] ?? [])
             ->first(function (array $value, string $name) {
-                return $name === '@protonemedia/laravel-splade';
+                return Str::contains($name, '@protonemedia/laravel-splade');
             })['version'] ?? null;
 
         $composerPackage


### PR DESCRIPTION
New versions of [npm](https://docs.npmjs.com/cli/v8/using-npm/config#lockfile-version) use `package-lock.json` version **3**, which omits the `dependencies` section. This fix allows `splade:show-versions` command to work in both environments (`"lockfileVersion": 2` and `"lockfileVersion": 3`).