### PR TITLE
Allow HtmlString for label/help attributes

### DIFF
--- a/app/app/Forms/ExampleForm.php
+++ b/app/app/Forms/ExampleForm.php
@@ -61,7 +61,7 @@ class ExampleForm extends AbstractForm
                 ->rules('required|max:255'),
 
             Input::make('inputText3')
-                ->label('Input text field with fixed length(6)')
+                ->htmlLabel('Input text field with fixed <b>length(6)</b>')
                 ->length(6)
                 ->prepend('Test prepend'),
 
@@ -115,7 +115,7 @@ class ExampleForm extends AbstractForm
             Date::make('inputDate6')
                 ->label('Input type: date with range')
                 ->range()
-                ->help('Test help 2'),
+                ->htmlHelp('Test help 2 <b>with HTML</b>'),
 
             Time::make('inputTime1')
                 ->label('Input time field - with extra FlatPicker time-options: { time_24hr: false }')

--- a/src/Components/Button.php
+++ b/src/Components/Button.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
@@ -19,7 +20,7 @@ class Button extends Component
      * @return void
      */
     public function __construct(
-        public string $label = 'Submit',
+        public HtmlString|string $label = 'Submit',
         public string $type = 'submit',
         public string $name = '',
         public $value = null,

--- a/src/Components/Form/Checkbox.php
+++ b/src/Components/Form/Checkbox.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components\Form;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use ProtoneMedia\Splade\Components\Form;
 
@@ -18,10 +19,10 @@ class Checkbox extends Component
         public string $name = '',
         public string $vModel = '',
         public $value = true,
-        public string $label = '',
+        public HtmlString|string $label = '',
         public string $validationKey = '',
         public bool $showErrors = true,
-        public string $help = '',
+        public HtmlString|string $help = '',
         public bool $relation = false,
         public $falseValue = false,
     ) {

--- a/src/Components/Form/Checkboxes.php
+++ b/src/Components/Form/Checkboxes.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components\Form;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use ProtoneMedia\Splade\Components\Form;
 use ProtoneMedia\Splade\Components\SpladeComponent;
@@ -18,9 +19,9 @@ class Checkboxes extends Component
     public function __construct(
         public string $name = '',
         public $options = [],
-        public string $label = '',
+        public HtmlString|string $label = '',
         public bool $inline = false,
-        public string $help = '',
+        public HtmlString|string $help = '',
         public bool $relation = false
     ) {
         Form::allowAttribute($name);

--- a/src/Components/Form/File.php
+++ b/src/Components/Form/File.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components\Form;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use ProtoneMedia\Splade\Components\Form;
 
@@ -21,13 +22,13 @@ class File extends Component
     public function __construct(
         public string $name = '',
         public string $vModel = '',
-        public string $label = '',
+        public HtmlString|string $label = '',
         public bool|string $placeholder = true,
         public string $validationKey = '',
         public bool $showErrors = true,
         public bool $multiple = false,
         public string $scope = 'file',
-        public string $help = '',
+        public HtmlString|string $help = '',
         public bool|array|string|null $filepond = null,
         public bool|string $server = false,
         public bool $preview = false,

--- a/src/Components/Form/Group.php
+++ b/src/Components/Form/Group.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components\Form;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 
 class Group extends Component
@@ -15,11 +16,11 @@ class Group extends Component
      */
     public function __construct(
         public string $name = '',
-        public string $label = '',
+        public HtmlString|string $label = '',
         public bool $inline = false,
         public string $validationKey = '',
         public bool $showErrors = true,
-        public string $help = '',
+        public HtmlString|string $help = '',
     ) {
     }
 

--- a/src/Components/Form/Input.php
+++ b/src/Components/Form/Input.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components\Form;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use ProtoneMedia\Splade\Components\Form;
 
@@ -26,15 +27,15 @@ class Input extends Component
         public string $name = '',
         public string $vModel = '',
         public string $type = 'text',
-        public string $label = '',
+        public HtmlString|string $label = '',
         private bool|array|string|null $date = null,
         private bool|array|string|null $time = null,
         public string $validationKey = '',
         public bool $showErrors = true,
         private bool $range = false,
-        public string $prepend = '',
-        public string $append = '',
-        public string $help = '',
+        public HtmlString|string $prepend = '',
+        public HtmlString|string $append = '',
+        public HtmlString|string $help = '',
         public bool $alwaysEnablePrepend = false,
         public bool $alwaysEnableAppend = false,
     ) {

--- a/src/Components/Form/Radio.php
+++ b/src/Components/Form/Radio.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components\Form;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use ProtoneMedia\Splade\Components\Form;
 
@@ -18,10 +19,10 @@ class Radio extends Component
         public string $name = '',
         public string $vModel = '',
         public $value = 1,
-        public string $label = '',
+        public HtmlString|string $label = '',
         public string $validationKey = '',
         public bool $showErrors = false,
-        public string $help = '',
+        public HtmlString|string $help = '',
     ) {
         Form::allowAttribute($name);
     }

--- a/src/Components/Form/Radios.php
+++ b/src/Components/Form/Radios.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components\Form;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use ProtoneMedia\Splade\Components\Form;
 use ProtoneMedia\Splade\Components\SpladeComponent;
@@ -18,9 +19,9 @@ class Radios extends Component
     public function __construct(
         public string $name = '',
         public $options = [],
-        public string $label = '',
+        public HtmlString|string $label = '',
         public bool $inline = false,
-        public string $help = ''
+        public HtmlString|string $help = ''
     ) {
         Form::allowAttribute($name);
     }

--- a/src/Components/Form/Select.php
+++ b/src/Components/Form/Select.php
@@ -4,6 +4,7 @@ namespace ProtoneMedia\Splade\Components\Form;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Js;
 use Illuminate\Support\Str;
 use Illuminate\View\Component;
@@ -29,14 +30,14 @@ class Select extends Component
         public string $name = '',
         public string $vModel = '',
         public $options = [],
-        public string $label = '',
+        public HtmlString|string $label = '',
         public bool|string $placeholder = '',
         public bool $multiple = false,
         public bool|array|string|null $choices = null,
         public string $validationKey = '',
         public bool $showErrors = true,
         public bool $relation = false,
-        public string $help = '',
+        public HtmlString|string $help = '',
         public string $remoteUrl = '',
         public string $remoteRoot = '',
         public string $optionValue = '',

--- a/src/Components/Form/Submit.php
+++ b/src/Components/Form/Submit.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components\Form;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use Illuminate\View\ComponentAttributeBag;
 use ProtoneMedia\Splade\Components\Button;
@@ -19,7 +20,7 @@ class Submit extends Component
      * @return void
      */
     public function __construct(
-        public string $label = 'Submit',
+        public HtmlString|string $label = 'Submit',
         public string $type = 'submit',
         public bool $spinner = true,
         public string $name = '',

--- a/src/Components/Form/Textarea.php
+++ b/src/Components/Form/Textarea.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\Components\Form;
 
+use Illuminate\Support\HtmlString;
 use Illuminate\View\Component;
 use ProtoneMedia\Splade\Components\Form;
 
@@ -19,10 +20,10 @@ class Textarea extends Component
     public function __construct(
         public string $name = '',
         public string $vModel = '',
-        public string $label = '',
+        public HtmlString|string $label = '',
         public string $validationKey = '',
         public bool $showErrors = true,
-        public string $help = '',
+        public HtmlString|string $help = '',
     ) {
         Form::allowAttribute($name);
     }

--- a/src/FormBuilder/Component.php
+++ b/src/FormBuilder/Component.php
@@ -3,6 +3,7 @@
 namespace ProtoneMedia\Splade\FormBuilder;
 
 use Illuminate\Support\Arr;
+use Illuminate\Support\HtmlString;
 use Illuminate\Support\Traits\Macroable;
 use ProtoneMedia\Splade\Components\Form\InteractsWithFormElement;
 
@@ -15,11 +16,11 @@ abstract class Component
 
     protected string $name = '';
 
-    protected string $label = '';
+    protected HtmlString|string $label = '';
 
     protected array $attributes = [];
 
-    protected string $help = '';
+    protected HtmlString|string $help = '';
 
     public array|string $rules = [];
 
@@ -42,11 +43,21 @@ abstract class Component
      *
      * @return $this
      */
-    public function label(string $label): self
+    public function label(HtmlString|string $label): self
     {
         $this->label = $label;
 
         return $this;
+    }
+
+    /**
+     * Add a label to the field that won't be escaped
+     *
+     * @return $this
+     */
+    public function htmlLabel(HtmlString|string $label): self
+    {
+        return $this->label(is_string($label) ? new HtmlString($label) : $label);
     }
 
     /**
@@ -81,11 +92,21 @@ abstract class Component
      *
      * @return $this
      */
-    public function help(string $text): self
+    public function help(HtmlString|string $text): self
     {
         $this->help = $text;
 
         return $this;
+    }
+
+    /**
+     * Add a help text to the field that won't be escaped
+     *
+     * @return $this
+     */
+    public function htmlHelp(HtmlString|string $text): self
+    {
+        return $this->help(is_string($text) ? new HtmlString($text) : $text);
     }
 
     /**


### PR DESCRIPTION
A follow-up to #369. Adds `htmlLabel` and `htmlHelp` methods to allow texts that won't be escaped.

```php
Input::make('hiddenInput2')
    ->htmlLabel('Title <span class="text-red-500">*</span>');

// which will be a shortcut to:

Input::make('hiddenInput2')
    ->label(new HtmlString('Title <span class="text-red-500">*</span>'));
```
