### PR TITLE
Version bump (Vite 4.0)

### DIFF
--- a/src/Commands/SpladeInstallCommand.php
+++ b/src/Commands/SpladeInstallCommand.php
@@ -33,7 +33,7 @@ class SpladeInstallCommand extends Command
                 '@protonemedia/laravel-splade' => '^1.4.7',
                 '@tailwindcss/forms'           => '^0.5.2',
                 '@tailwindcss/typography'      => '^0.5.2',
-                '@vitejs/plugin-vue'           => '^3.0.0',
+                '@vitejs/plugin-vue'           => '^4.1.0',
                 'autoprefixer'                 => '^10.4.7',
                 'laravel-vite-plugin'          => '^0.7.2',
                 'postcss'                      => '^8.4.14',

--- a/src/Commands/SpladeInstallCommand.php
+++ b/src/Commands/SpladeInstallCommand.php
@@ -35,10 +35,10 @@ class SpladeInstallCommand extends Command
                 '@tailwindcss/typography'      => '^0.5.2',
                 '@vitejs/plugin-vue'           => '^3.0.0',
                 'autoprefixer'                 => '^10.4.7',
-                'laravel-vite-plugin'          => '^0.5.0',
+                'laravel-vite-plugin'          => '^0.7.2',
                 'postcss'                      => '^8.4.14',
                 'tailwindcss'                  => '^3.1.0',
-                'vite'                         => '^3.0.0',
+                'vite'                         => '^4.0.0',
                 'vue'                          => '^3.2.37',
             ] + $packages;
         });


### PR DESCRIPTION
Version bump because the `php artisan splade:install` command overwrites the default Laravel 9.x / 10.x  devDependencies:
```
    "devDependencies": {
        ...
        "laravel-vite-plugin": "^0.7.2",
        "vite": "^4.0.0"
    }
```
into:
```
    "devDependencies": {
        ...
        "laravel-vite-plugin": "^0.5.0",
        ...
        "vite": "^3.0.0",
        ...
    }
```

