### PR TITLE
Wrapper for submit buttons

### DIFF
--- a/resources/views/form/submit.blade.php
+++ b/resources/views/form/submit.blade.php
@@ -1,29 +1,31 @@
 @php $customStyling = $hasCustomStyling($attributes) @endphp
 
-<button {{ $attributes->class([
-    'border rounded-md shadow-sm font-bold py-2 px-4 focus:outline-none focus:ring focus:ring-opacity-50',
-    'bg-indigo-500 hover:bg-indigo-700 text-white border-transparent focus:border-indigo-300 focus:ring-indigo-200' => !$customStyling && $primary,
-    'bg-red-500 hover:bg-red-700 text-white border-transparent focus:border-red-700 focus:ring-red-200' => !$customStyling && $danger,
-    'bg-white hover:bg-gray-100 text-gray-700 border-gray-300 focus:border-indigo-300 focus:ring-indigo-200' => !$customStyling && $secondary,
-])->merge([
-    'type' => $type
-])->when($name, fn($attr) => $attr->merge(['name' => $name, 'value' => $value])) }}
->
-    @if(trim($slot))
-        {{ $slot }}
-    @else
-        <div class="flex flex-row items-center justify-center">
-            <svg
-                v-if="@js($spinner) && form.processing"
-                class="animate-spin mr-3 h-5 w-5 @if($secondary) text-gray-700 @else text-white @endif" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-            >
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-            </svg>
+<div @class($parentClasses)>
+    <button {{ $attributes->class([
+        'border rounded-md shadow-sm font-bold py-2 px-4 focus:outline-none focus:ring focus:ring-opacity-50',
+        'bg-indigo-500 hover:bg-indigo-700 text-white border-transparent focus:border-indigo-300 focus:ring-indigo-200' => !$customStyling && $primary,
+        'bg-red-500 hover:bg-red-700 text-white border-transparent focus:border-red-700 focus:ring-red-200' => !$customStyling && $danger,
+        'bg-white hover:bg-gray-100 text-gray-700 border-gray-300 focus:border-indigo-300 focus:ring-indigo-200' => !$customStyling && $secondary,
+    ])->merge([
+        'type' => $type
+    ])->when($name, fn($attr) => $attr->merge(['name' => $name, 'value' => $value])) }}
+    >
+        @if(trim($slot))
+            {{ $slot }}
+        @else
+            <div class="flex flex-row items-center justify-center">
+                <svg
+                    v-if="@js($spinner) && form.processing"
+                    class="animate-spin mr-3 h-5 w-5 @if($secondary) text-gray-700 @else text-white @endif" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                >
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
 
-            <span :class="{ 'opacity-50': form.processing || form.$uploading }">
-                {{ $label }}
-            </span>
-        </div>
-    @endif
-</button>
+                <span :class="{ 'opacity-50': form.processing || form.$uploading }">
+                    {{ $label }}
+                </span>
+            </div>
+        @endif
+    </button>
+</div>

--- a/src/Commands/SpladeInstallCommand.php
+++ b/src/Commands/SpladeInstallCommand.php
@@ -33,7 +33,7 @@ class SpladeInstallCommand extends Command
                 '@protonemedia/laravel-splade' => '^1.4.7',
                 '@tailwindcss/forms'           => '^0.5.2',
                 '@tailwindcss/typography'      => '^0.5.2',
-                '@vitejs/plugin-vue'           => '^3.0.0',
+                '@vitejs/plugin-vue'           => '^4.1.0',
                 'autoprefixer'                 => '^10.4.7',
                 'laravel-vite-plugin'          => '^0.7.2',
                 'postcss'                      => '^8.4.14',

--- a/src/Commands/SpladeInstallCommand.php
+++ b/src/Commands/SpladeInstallCommand.php
@@ -33,12 +33,12 @@ class SpladeInstallCommand extends Command
                 '@protonemedia/laravel-splade' => '^1.4.7',
                 '@tailwindcss/forms'           => '^0.5.2',
                 '@tailwindcss/typography'      => '^0.5.2',
-                '@vitejs/plugin-vue'           => '^4.1.0',
+                '@vitejs/plugin-vue'           => '^3.0.0',
                 'autoprefixer'                 => '^10.4.7',
-                'laravel-vite-plugin'          => '^0.7.2',
+                'laravel-vite-plugin'          => '^0.5.0',
                 'postcss'                      => '^8.4.14',
                 'tailwindcss'                  => '^3.1.0',
-                'vite'                         => '^4.0.0',
+                'vite'                         => '^3.0.0',
                 'vue'                          => '^3.2.37',
             ] + $packages;
         });

--- a/src/Commands/SpladeInstallCommand.php
+++ b/src/Commands/SpladeInstallCommand.php
@@ -35,10 +35,10 @@ class SpladeInstallCommand extends Command
                 '@tailwindcss/typography'      => '^0.5.2',
                 '@vitejs/plugin-vue'           => '^3.0.0',
                 'autoprefixer'                 => '^10.4.7',
-                'laravel-vite-plugin'          => '^0.5.0',
+                'laravel-vite-plugin'          => '^0.7.2',
                 'postcss'                      => '^8.4.14',
                 'tailwindcss'                  => '^3.1.0',
-                'vite'                         => '^3.0.0',
+                'vite'                         => '^4.0.0',
                 'vue'                          => '^3.2.37',
             ] + $packages;
         });

--- a/src/Components/Form/Submit.php
+++ b/src/Components/Form/Submit.php
@@ -27,6 +27,7 @@ class Submit extends Component
         public $value = null,
         public $danger = false,
         public $secondary = false,
+        public string $parentClasses = '',
     ) {
         $this->primary = !$this->danger && !$this->secondary;
     }

--- a/src/FormBuilder/Button.php
+++ b/src/FormBuilder/Button.php
@@ -2,6 +2,7 @@
 
 namespace ProtoneMedia\Splade\FormBuilder;
 
+use Illuminate\Support\Arr;
 use ProtoneMedia\Splade\Components\Form\Submit as SpladeSubmit;
 use ProtoneMedia\Splade\FormBuilder\Concerns\HasValue;
 
@@ -11,6 +12,8 @@ class Button extends Component
 
     protected bool $danger = false;
 
+    protected string $parentClasses = '';
+
     protected bool $secondary = false;
 
     protected bool $spinner = true;
@@ -18,7 +21,7 @@ class Button extends Component
     protected string $type = 'button';
 
     /**
-     * Applies danger-styling to the button
+     * Applies danger-styling to the button.
      *
      * @return $this
      */
@@ -30,9 +33,24 @@ class Button extends Component
     }
 
     /**
-     * Applies secondary-styling to the button
+     * Add one or more classes to the fields' wrapper.
      *
-     * @param  bool  $danger
+     * @param  array|string  $classes
+     * @return $this
+     */
+    public function parentClass(...$classes): self
+    {
+        $classes = Arr::flatten($classes);
+
+        $this->parentClasses = Arr::toCssClasses($classes);
+
+        return $this;
+    }
+
+    /**
+     * Applies secondary-styling to the button.
+     *
+     * @param  bool  $secondary
      * @return $this
      */
     public function secondary(bool $secondary = true): self
@@ -50,13 +68,14 @@ class Button extends Component
     public function toSpladeComponent()
     {
         return new SpladeSubmit(
-            label:     $this->label,
-            type:      $this->type,
-            spinner:   $this->spinner,
-            name:      $this->name,
-            value:     $this->value ?? null,
-            danger:    $this->danger,
-            secondary: $this->secondary
+            label:          $this->label,
+            type:           $this->type,
+            spinner:        $this->spinner,
+            name:           $this->name,
+            value:          $this->value ?? null,
+            danger:         $this->danger,
+            secondary:      $this->secondary,
+            parentClasses:  $this->parentClasses
         );
     }
 }


### PR DESCRIPTION
Added a wrapper around submit buttons in order to be able to apply separate styling to the button and its wrapper, for example:

```php
<?php

namespace App\Forms;

use ProtoneMedia\Splade\AbstractForm;
use ProtoneMedia\Splade\FormBuilder\Submit;
use ProtoneMedia\Splade\FormBuilder\Text;
use ProtoneMedia\Splade\FormBuilder\Textarea;
use ProtoneMedia\Splade\SpladeForm;

class ProfileForm extends AbstractForm
{
    public function configure(SpladeForm $form)
    {
        $form->class('grid grid-cols-2 gap-4');
    }

    public function fields(): array
    {
        return [
            Text::make('first_name')->label(__('First name')),

            Text::make('last_name')->label(__('Last name')),

            Textarea::make('bio')->label('Biography')->class('col-span-2'),

            Submit::make()->label(__('Save'))->parentClass('col-span-2 text-center'),
        ];
    }
}
```

The example above will now look like:

![afbeelding](https://user-images.githubusercontent.com/16107428/229362140-06f06049-1fde-489b-ad26-2287f70e9b2d.png)
