### PR TITLE
Add blob option for Form Builder

### DIFF
--- a/resources/views/functional/form-builder.blade.php
+++ b/resources/views/functional/form-builder.blade.php
@@ -22,6 +22,8 @@
     :restore-on-success="$form->getOption('restore_on_success')"
 
     :preserve-scroll="$form->getOption('preserve_scroll')"
+
+    :blob="$form->getOption('blob')"
 >
     @foreach($form->getFields() as $field)
         {!! $field->render() !!}

--- a/src/SpladeForm.php
+++ b/src/SpladeForm.php
@@ -301,4 +301,18 @@ class SpladeForm
 
         return $request->validate($this->getRules(), ...$params);
     }
+
+    /**
+     * Handle server response as a blob to allow downloading files.
+     *
+     * @param  bool  $blob
+     * @return $this
+     */
+    public function blob(bool $blob = true): self
+    {
+        $this->options['blob'] = $blob;
+
+        return $this;
+    }
+
 }


### PR DESCRIPTION
The blob attribute was added in 1.4.10.  This change adds a blob option to Form Builder so downloads will work.

```php
SpladeForm::make()
    ->id('create-user-form')
    ->class('space-y-4')
    ->method('POST')
    ->blob(true);
```