### PR TITLE
Allow markup in checkbox label

### DIFF
--- a/resources/views/form/checkbox.blade.php
+++ b/resources/views/form/checkbox.blade.php
@@ -13,7 +13,7 @@
         @if(trim($slot))
             <span class="ml-2">{{ $slot }}</span>
         @else
-            <span class="ml-2">{{ $label }}</span>
+            <span class="ml-2">{!! $label !!}</span>
         @endif
     </label>
 


### PR DESCRIPTION
A tiny change to unescape checkbox label strings, allowing for links to be added. Useful for a privacy policy link on a checkbox.