### PR TITLE
Allow ComponentSlot as $slot-parameter type in PersistentComponent viewData

### DIFF
--- a/src/Components/PersistentComponent.php
+++ b/src/Components/PersistentComponent.php
@@ -50,7 +50,7 @@ abstract class PersistentComponent extends Component
      * into Splade Dynamic comments, and merges them it the
      * default data from the original view.
      */
-    public function viewData(array $originalData, HtmlString $slot, Factory $env): array
+    public function viewData(array $originalData, ComponentSlot|HtmlString $slot, Factory $env): array
     {
         $slots = Collection::make($env->getFirstSlot())->map(function (ComponentSlot $slot, $name) {
             return new ComponentSlot(


### PR DESCRIPTION
This PR fixes an error we faced while using the PersistentComponent:
```
ProtoneMedia\Splade\Components\PersistentComponent::viewData(): Argument #2 ($slot) must be of type Illuminate\Support\HtmlString, Illuminate\View\ComponentSlot given.
```