### PR TITLE
Add usage support for power joins v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "phpunit/phpunit": "^9.5"
     },
     "suggest": {
-        "kirschbaum-development/eloquent-power-joins": "Required to enable support sorting by (nested) relationships in Splade Tables (^2.6)",
+        "kirschbaum-development/eloquent-power-joins": "Required to enable support sorting by (nested) relationships in Splade Tables (^3.0|^2.6)",
         "maatwebsite/excel": "Required to enable support exports in Splade Tables (^3.1)",
         "spatie/fractalistic": "Required to enable support for Fractal transformers (^2.9)"
     },

--- a/src/SpladeQueryBuilder.php
+++ b/src/SpladeQueryBuilder.php
@@ -209,13 +209,18 @@ class SpladeQueryBuilder extends SpladeTable
             );
         }
 
-        if (!method_exists($this->builder->getModel(), 'scopeOrderByLeftPowerJoins')) {
+        if (!method_exists($this->builder->getModel(), 'scopeOrderByLeftPowerJoins') && !method_exists($this->builder, 'orderByLeftPowerJoins'){
             throw new PowerJoinsException(
                 "To order the query using a column from a relationship, make sure the Model uses the 'PowerJoins' trait."
             );
         }
 
         // Apply the sorting using the PowerJoins package.
+        // @deprecated The 'scopeOrderByLeftPowerJoins' method means it's using the old version of the package.
+        if (method_exists($this->builder->getModel(), 'scopeOrderByLeftPowerJoins')) {
+            return $this->builder->orderByLeftPowerJoins($column->key, $column->sorted);
+        }
+
         return $this->builder->orderByLeftPowerJoins($column->key, $column->sorted);
     }
 


### PR DESCRIPTION
First, I want to say it was a nice surprise to see the support for sorting the table component using Power Joins!

This PR is coming after [this issue](https://github.com/kirschbaum-development/eloquent-power-joins/issues/171) that was opened in the power joins repo directly. After a bit of digging, I saw that the package is using and checking the methods from v2, while we have some different ways of handling this on v3.

I believe we can make v2 or v3 work, depending only on what the user has installed. I pushed this PR with an attempt to solve this, but I wasn't able to actually test this yet. Do you have an easy way to verify if this is working? Otherwise, I'll try to create a demo project to make sure this is working.